### PR TITLE
Centralize block encoding and padding in stream_codec.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ set(PUBLIC_HEADERS
     cppcodec/detail/base32.hpp
     cppcodec/detail/base64.hpp
     cppcodec/detail/codec.hpp
+    cppcodec/detail/config.hpp
     cppcodec/detail/hex.hpp
     cppcodec/detail/stream_codec.hpp)
 

--- a/cppcodec/detail/base32.hpp
+++ b/cppcodec/detail/base32.hpp
@@ -35,6 +35,7 @@
 
 #include "../data/access.hpp"
 #include "../parse_error.hpp"
+#include "config.hpp"
 #include "stream_codec.hpp"
 
 namespace cppcodec {
@@ -47,18 +48,38 @@ public:
     static inline constexpr uint8_t binary_block_size() { return 5; }
     static inline constexpr uint8_t encoded_block_size() { return 8; }
 
-    template <typename Result, typename ResultState>
-    static void encode_block(Result& encoded, ResultState&, const uint8_t* src);
+    static CPPCODEC_ALWAYS_INLINE constexpr uint8_t num_encoded_tail_symbols(uint8_t num_bytes) noexcept
+    {
+        return (num_bytes == 1) ? 2    // 2 symbols, 6 padding characters
+                : (num_bytes == 2) ? 4 // 4 symbols, 4 padding characters
+                : (num_bytes == 3) ? 5 // 5 symbols, 3 padding characters
+                : (num_bytes == 4) ? 7 // 7 symbols, 1 padding characters
+                : throw std::domain_error("invalid number of bytes in a tail block");
+    }
 
-    template <typename Result, typename ResultState>
-    static void encode_tail(Result& encoded, ResultState&, const uint8_t* src, size_t src_len);
+    template <uint8_t I> CPPCODEC_ALWAYS_INLINE static constexpr uint8_t index(
+            const uint8_t* b /*binary block*/) noexcept
+    {
+        return (I == 0) ? ((b[0] >> 3) & 0x1F) // first 5 bits
+                : (I == 1) ? (((b[0] << 2) & 0x1C) | ((b[1] >> 6) & 0x3))
+                : (I == 2) ? ((b[1] >> 1) & 0x1F)
+                : (I == 3) ? (((b[1] << 4) & 0x10) | ((b[2] >> 4) & 0xF))
+                : (I == 4) ? (((b[2] << 1) & 0x1E) | ((b[3] >> 7) & 0x1))
+                : (I == 5) ? ((b[3] >> 2) & 0x1F)
+                : (I == 6) ? (((b[3] << 3) & 0x18) | ((b[4] >> 5) & 0x7))
+                : (I == 7) ? (b[4] & 0x1F) // last 5 bits
+                : throw std::domain_error("invalid encoding symbol index in a block");
+    }
 
-    template <typename Result, typename ResultState>
-    static void pad(Result&, ResultState&, ...) { } // lower priority overload
-
-    template <typename Result, typename ResultState, typename V = CodecVariant,
-            typename std::enable_if<V::generates_padding()>::type* = nullptr>
-    static void pad(Result& encoded, ResultState&, size_t remaining_src_len);
+    template <uint8_t I> CPPCODEC_ALWAYS_INLINE static constexpr uint8_t index_last(
+            const uint8_t* b /*binary block*/) noexcept
+    {
+        return (I == 1) ? ((b[0] << 2) & 0x1C)    // abbreviated 2nd symbol
+                : (I == 3) ? ((b[1] << 4) & 0x10) // abbreviated 4th symbol
+                : (I == 4) ? ((b[2] << 1) & 0x1E) // abbreviated 5th symbol
+                : (I == 6) ? ((b[3] << 3) & 0x18) // abbreviated 7th symbol
+                : throw std::domain_error("invalid last encoding symbol index in a tail");
+    }
 
     template <typename Result, typename ResultState>
     static void decode_block(Result& decoded, ResultState&, const uint8_t* idx);
@@ -71,74 +92,6 @@ public:
 //     11111111 10101010 10110011  10111100 10010100
 // => 11111 11110 10101 01011 00111 01111 00100 10100
 //
-
-template <typename CodecVariant>
-template <typename Result, typename ResultState>
-inline void base32<CodecVariant>::encode_block(
-        Result& encoded, ResultState& state, const uint8_t* src)
-{
-    using V = CodecVariant;
-    data::put(encoded, state, V::symbol((src[0] >> 3) & 0x1F)); // first 5 bits
-    data::put(encoded, state, V::symbol(((src[0] << 2) & 0x1C) | ((src[1] >> 6) & 0x3))); // last 3 + next 2
-    data::put(encoded, state, V::symbol((src[1] >> 1) & 0x1F)); // next 5 bits (tail has 1 bit)
-    data::put(encoded, state, V::symbol(((src[1] << 4) & 0x10) | ((src[2] >> 4) & 0xF))); // last 1 + next 4
-    data::put(encoded, state, V::symbol(((src[2] << 1) & 0x1E) | ((src[3] >> 7) & 0x1)));
-    data::put(encoded, state, V::symbol((src[3] >> 2) & 0x1F));
-    data::put(encoded, state, V::symbol(((src[3] << 3) & 0x18) | ((src[4] >> 5) & 0x7)));
-    data::put(encoded, state, V::symbol((src[4] & 0x1F)));
-}
-
-template <typename CodecVariant>
-template <typename Result, typename ResultState>
-inline void base32<CodecVariant>::encode_tail(
-        Result& encoded, ResultState& state, const uint8_t* src, size_t remaining_src_len)
-{
-    using V = CodecVariant;
-
-    data::put(encoded, state, V::symbol((src[0] >> 3) & 0x1F)); // encoded size 1
-    if (remaining_src_len == 1) {
-        data::put(encoded, state, V::symbol((src[0] << 2) & 0x1C)); // size 2
-        return;
-    }
-    data::put(encoded, state, V::symbol(((src[0] << 2) & 0x1C) | ((src[1] >> 6) & 0x3))); // size 2
-    data::put(encoded, state, V::symbol((src[1] >> 1) & 0x1F)); // size 3
-    if (remaining_src_len == 2) {
-        data::put(encoded, state, V::symbol((src[1] << 4) & 0x10)); // size 4
-        return;
-    }
-    data::put(encoded, state, V::symbol(((src[1] << 4) & 0x10) | ((src[2] >> 4) & 0xF))); // size 4
-    if (remaining_src_len == 3) {
-        data::put(encoded, state, V::symbol((src[2] << 1) & 0x1E)); // size 5
-        return;
-    }
-    data::put(encoded, state, V::symbol(((src[2] << 1) & 0x1E) | ((src[3] >> 7) & 0x1))); // size 5
-    data::put(encoded, state, V::symbol((src[3] >> 2) & 0x1F)); // size 6
-    if (remaining_src_len == 4) {
-        data::put(encoded, state, V::symbol((src[3] << 3) & 0x18)); // size 7
-        return;
-    }
-    abort(); // not reached: encode_block() should be called if remaining_src_len > 4, not this function
-}
-
-template <typename CodecVariant>
-template <typename Result, typename ResultState, typename V,
-        typename std::enable_if<V::generates_padding()>::type*>
-inline void base32<CodecVariant>::pad(
-        Result& encoded, ResultState& state, size_t remaining_src_len)
-{
-    switch (remaining_src_len) {
-    case 1: // 2 symbols, 6 padding characters
-        data::put(encoded, state, CodecVariant::padding_symbol());
-        data::put(encoded, state, CodecVariant::padding_symbol());
-    case 2: // 4 symbols, 4 padding characters
-        data::put(encoded, state, CodecVariant::padding_symbol());
-    case 3: // 5 symbols, 3 padding characters
-        data::put(encoded, state, CodecVariant::padding_symbol());
-        data::put(encoded, state, CodecVariant::padding_symbol());
-    case 4: // 7 symbols, 1 padding character
-        data::put(encoded, state, CodecVariant::padding_symbol());
-    }
-}
 
 template <typename CodecVariant>
 template <typename Result, typename ResultState>

--- a/cppcodec/detail/config.hpp
+++ b/cppcodec/detail/config.hpp
@@ -1,0 +1,38 @@
+/**
+ *  Copyright (C) 2015 Topology LP
+ *  All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ *  deal in the Software without restriction, including without limitation the
+ *  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ *  sell copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ *  IN THE SOFTWARE.
+ */
+
+#ifndef CPPCODEC_DETAIL_CONFIG_HPP
+#define CPPCODEC_DETAIL_CONFIG_HPP
+
+#ifndef __has_attribute
+  #define __has_attribute(x) 0
+#endif
+
+#if __GNUC__ || __has_attribute(always_inline)
+#define CPPCODEC_ALWAYS_INLINE inline __attribute__((always_inline))
+#else
+#define CPPCODEC_ALWAYS_INLINE inline
+#endif
+
+#endif // CPPCODEC_DETAIL_CONFIG_HPP
+

--- a/cppcodec/detail/stream_codec.hpp
+++ b/cppcodec/detail/stream_codec.hpp
@@ -28,6 +28,7 @@
 #include <stdint.h>
 
 #include "../parse_error.hpp"
+#include "config.hpp"
 
 namespace cppcodec {
 namespace detail {
@@ -46,19 +47,86 @@ public:
     static constexpr size_t decoded_max_size(size_t encoded_size) noexcept;
 };
 
+template <bool GeneratesPadding> // default for CodecVariant::generates_padding() == false
+struct padder {
+    template <typename CodecVariant, typename Result, typename ResultState, typename EncodedBlockSizeT>
+    CPPCODEC_ALWAYS_INLINE void operator()(Result&, ResultState&, EncodedBlockSizeT) { }
+};
+
+template<> // specialization for CodecVariant::generates_padding() == true
+struct padder<true> {
+    template <typename CodecVariant, typename Result, typename ResultState, typename EncodedBlockSizeT>
+    CPPCODEC_ALWAYS_INLINE void operator()(
+            Result& encoded, ResultState& state, EncodedBlockSizeT num_padding_characters)
+    {
+        for (EncodedBlockSizeT i = 0; i < num_padding_characters; ++i) {
+            data::put(encoded, state, CodecVariant::padding_symbol());
+        }
+    }
+};
+
+template <size_t I>
+struct enc {
+    // Block encoding: Go from 0 to (block size - 1), append a symbol for each iteration unconditionally.
+    template <typename Codec, typename CodecVariant, typename Result, typename ResultState>
+    static CPPCODEC_ALWAYS_INLINE void block(Result& encoded, ResultState& state, const uint8_t* src)
+    {
+        using EncodedBlockSizeT = decltype(Codec::encoded_block_size());
+        constexpr static const EncodedBlockSizeT SymbolIndex = static_cast<EncodedBlockSizeT>(I - 1);
+
+        enc<I - 1>().template block<Codec, CodecVariant>(encoded, state, src);
+        data::put(encoded, state, CodecVariant::symbol(Codec::template index<SymbolIndex>(src)));
+    }
+
+    // Tail encoding: Go from 0 until (runtime) num_symbols, append a symbol for each iteration.
+    template <typename Codec, typename CodecVariant, typename Result, typename ResultState,
+            typename EncodedBlockSizeT = decltype(Codec::encoded_block_size())>
+    static CPPCODEC_ALWAYS_INLINE void tail(
+            Result& encoded, ResultState& state, const uint8_t* src, EncodedBlockSizeT num_symbols)
+    {
+        constexpr static const EncodedBlockSizeT SymbolIndex = Codec::encoded_block_size() - I;
+        constexpr static const EncodedBlockSizeT NumSymbols = SymbolIndex + static_cast<EncodedBlockSizeT>(1);
+
+        if (num_symbols == NumSymbols) {
+            data::put(encoded, state, CodecVariant::symbol(Codec::template index_last<SymbolIndex>(src)));
+            padder<CodecVariant::generates_padding()> pad;
+            pad.template operator()<CodecVariant>(encoded, state, Codec::encoded_block_size() - NumSymbols);
+            return;
+        }
+        data::put(encoded, state, CodecVariant::symbol(Codec::template index<SymbolIndex>(src)));
+        enc<I - 1>().template tail<Codec, CodecVariant>(encoded, state, src, num_symbols);
+    }
+};
+
+template<> // terminating specialization
+struct enc<0> {
+
+    template <typename Codec, typename CodecVariant, typename Result, typename ResultState>
+    static CPPCODEC_ALWAYS_INLINE void block(Result&, ResultState&, const uint8_t*) { }
+
+    template <typename Codec, typename CodecVariant, typename Result, typename ResultState,
+            typename EncodedBlockSizeT = decltype(Codec::encoded_block_size())>
+    static CPPCODEC_ALWAYS_INLINE void tail(Result&, ResultState&, const uint8_t*, EncodedBlockSizeT)
+    {
+        abort(); // Not reached: block() should be called if num_symbols == block size, not tail().
+    }
+};
+
 template <typename Codec, typename CodecVariant>
 template <typename Result, typename ResultState>
 inline void stream_codec<Codec, CodecVariant>::encode(
         Result& encoded_result, ResultState& state,
         const uint8_t* src, size_t src_size)
 {
+    using encoder = enc<Codec::encoded_block_size()>;
+
     const uint8_t* src_end = src + src_size;
 
     if (src_size >= Codec::binary_block_size()) {
         src_end -= Codec::binary_block_size();
 
         for (; src <= src_end; src += Codec::binary_block_size()) {
-            Codec::encode_block(encoded_result, state, src);
+            encoder::template block<Codec, CodecVariant>(encoded_result, state, src);
         }
         src_end += Codec::binary_block_size();
     }
@@ -69,8 +137,8 @@ inline void stream_codec<Codec, CodecVariant>::encode(
             abort();
             return;
         }
-        Codec::encode_tail(encoded_result, state, src, remaining_src_len);
-        Codec::pad(encoded_result, state, remaining_src_len);
+        auto num_symbols = Codec::num_encoded_tail_symbols(remaining_src_len);
+        encoder::template tail<Codec, CodecVariant>(encoded_result, state, src, num_symbols);
     }
 }
 


### PR DESCRIPTION
Codecs now only specify their shifted-bytes-to-index mappings
declaratively in a function index<I>(const uint8_t* binary_block).

stream_codec takes over the implementation of encode_block(),
encode_tail() and pad(). The templates used for this purpose
have been designed and measured to preserve space and runtime
behaviour by using the always_inline attribute where appropriate.

Decoding implementations are untouched for now. I might
decide to centralize them into stream_codec later as well.

Since pad() was rewritten from scratch in a different way,
this commit likely also resolves the VC14 compiler error.

(I'll leave the VC14 issue open until we've got an Appveyor build.)