### PR TITLE
Return type fix

### DIFF
--- a/cppcodec/data/access.hpp
+++ b/cppcodec/data/access.hpp
@@ -131,7 +131,7 @@ public:
     {
         result.resize(m_offset);
     }
-    inline void size(const Result&)
+    inline size_t size(const Result&)
     {
         return m_offset;
     }


### PR DESCRIPTION
direct_data_access_result_state::size was declared without a return-type, but tried to return a size_t, which prevented the code from compiling (GCC 6.1.1). Since returning a size_t makes sense, I fixed it by changing the declaration.
Compilation and Base32 worked fine afterwards.