### PR TITLE
Fix for the "-Wterminate" warnings of GCC 6

### DIFF
--- a/cppcodec/detail/base32.hpp
+++ b/cppcodec/detail/base32.hpp
@@ -48,7 +48,7 @@ public:
     static inline constexpr uint8_t binary_block_size() { return 5; }
     static inline constexpr uint8_t encoded_block_size() { return 8; }
 
-    static CPPCODEC_ALWAYS_INLINE constexpr uint8_t num_encoded_tail_symbols(uint8_t num_bytes) noexcept
+    static CPPCODEC_ALWAYS_INLINE constexpr uint8_t num_encoded_tail_symbols(uint8_t num_bytes)
     {
         return (num_bytes == 1) ? 2    // 2 symbols, 6 padding characters
                 : (num_bytes == 2) ? 4 // 4 symbols, 4 padding characters
@@ -58,7 +58,7 @@ public:
     }
 
     template <uint8_t I> CPPCODEC_ALWAYS_INLINE static constexpr uint8_t index(
-            const uint8_t* b /*binary block*/) noexcept
+            const uint8_t* b /*binary block*/)
     {
         return (I == 0) ? ((b[0] >> 3) & 0x1F) // first 5 bits
                 : (I == 1) ? (((b[0] << 2) & 0x1C) | ((b[1] >> 6) & 0x3))
@@ -72,7 +72,7 @@ public:
     }
 
     template <uint8_t I> CPPCODEC_ALWAYS_INLINE static constexpr uint8_t index_last(
-            const uint8_t* b /*binary block*/) noexcept
+            const uint8_t* b /*binary block*/)
     {
         return (I == 1) ? ((b[0] << 2) & 0x1C)    // abbreviated 2nd symbol
                 : (I == 3) ? ((b[1] << 4) & 0x10) // abbreviated 4th symbol

--- a/cppcodec/detail/base64.hpp
+++ b/cppcodec/detail/base64.hpp
@@ -46,7 +46,7 @@ public:
     static inline constexpr uint8_t binary_block_size() { return 3; }
     static inline constexpr uint8_t encoded_block_size() { return 4; }
 
-    static CPPCODEC_ALWAYS_INLINE constexpr uint8_t num_encoded_tail_symbols(uint8_t num_bytes) noexcept
+    static CPPCODEC_ALWAYS_INLINE constexpr uint8_t num_encoded_tail_symbols(uint8_t num_bytes)
     {
         return (num_bytes == 1) ? 2    // 2 symbols, 2 padding characters
                 : (num_bytes == 2) ? 3 // 3 symbols, 1 padding character
@@ -54,7 +54,7 @@ public:
     }
 
     template <uint8_t I> CPPCODEC_ALWAYS_INLINE static constexpr uint8_t index(
-            const uint8_t* b /*binary block*/) noexcept
+            const uint8_t* b /*binary block*/)
     {
         return (I == 0) ? (b[0] >> 2) // first 6 bits
                 : (I == 1) ? (((b[0] & 0x3) << 4) | (b[1] >> 4))
@@ -64,7 +64,7 @@ public:
     }
 
     template <uint8_t I> CPPCODEC_ALWAYS_INLINE static constexpr uint8_t index_last(
-            const uint8_t* b /*binary block*/) noexcept
+            const uint8_t* b /*binary block*/)
     {
         return (I == 1) ? ((b[0] & 0x3) << 4)    // abbreviated 2nd symbol
                 : (I == 2) ? ((b[1] & 0xF) << 2) // abbreviated 3rd symbol


### PR DESCRIPTION
This is just another small thing that came up when I started using cppcodec in my C++11 project.
There were a few methods which were defined with the noexcept-specifier but included a throw-statement. In C++11, when throwing an exception inside a noexcept-method, std::terminate() gets called instead of the usual exception handling. Usually this isn't the wanted behavior, which is why GCC 6 now spits out a warning message when doing that.
I resolved this by removing the noexcept-specifier from these methods. Since they were meant to get inlined and weren't introducing variables on the stack, this shouldn't affect performance in a negative way.