### PR TITLE
Fix for VC14 & warnings

### DIFF
--- a/cppcodec/detail/base32.hpp
+++ b/cppcodec/detail/base32.hpp
@@ -98,11 +98,11 @@ template <typename Result, typename ResultState>
 inline void base32<CodecVariant>::decode_block(
         Result& decoded, ResultState& state, const uint8_t* idx)
 {
-    put(decoded, state, (uint8_t)(((idx[0] << 3) & 0xF8) | ((idx[1] >> 2) & 0x7)));
-    put(decoded, state, (uint8_t)(((idx[1] << 6) & 0xC0) | ((idx[2] << 1) & 0x3E) | ((idx[3] >> 4) & 0x1)));
-    put(decoded, state, (uint8_t)(((idx[3] << 4) & 0xF0) | ((idx[4] >> 1) & 0xF)));
-    put(decoded, state, (uint8_t)(((idx[4] << 7) & 0x80) | ((idx[5] << 2) & 0x7C) | ((idx[6] >> 3) & 0x3)));
-    put(decoded, state, (uint8_t)(((idx[6] << 5) & 0xE0) | (idx[7] & 0x1F)));
+    put(decoded, state, static_cast<uint8_t>(((idx[0] << 3) & 0xF8) | ((idx[1] >> 2) & 0x7)));
+    put(decoded, state, static_cast<uint8_t>(((idx[1] << 6) & 0xC0) | ((idx[2] << 1) & 0x3E) | ((idx[3] >> 4) & 0x1)));
+    put(decoded, state, static_cast<uint8_t>(((idx[3] << 4) & 0xF0) | ((idx[4] >> 1) & 0xF)));
+    put(decoded, state, static_cast<uint8_t>(((idx[4] << 7) & 0x80) | ((idx[5] << 2) & 0x7C) | ((idx[6] >> 3) & 0x3)));
+    put(decoded, state, static_cast<uint8_t>(((idx[6] << 5) & 0xE0) | (idx[7] & 0x1F)));
 }
 
 template <typename CodecVariant>
@@ -124,22 +124,22 @@ inline void base32<CodecVariant>::decode_tail(
     }
 
     // idx_len == 2: decoded size 1
-    put(decoded, state, (uint8_t)(((idx[0] << 3) & 0xF8) | ((idx[1] >> 2) & 0x7)));
+    put(decoded, state, static_cast<uint8_t>(((idx[0] << 3) & 0xF8) | ((idx[1] >> 2) & 0x7)));
     if (idx_len == 2) {
         return;
     }
     // idx_len == 4: decoded size 2
-    put(decoded, state, (uint8_t)(((idx[1] << 6) & 0xC0) | ((idx[2] << 1) & 0x3E) | ((idx[3] >> 4) & 0x1)));
+    put(decoded, state, static_cast<uint8_t>(((idx[1] << 6) & 0xC0) | ((idx[2] << 1) & 0x3E) | ((idx[3] >> 4) & 0x1)));
     if (idx_len == 4) {
         return;
     }
     // idx_len == 5: decoded size 3
-    put(decoded, state, (uint8_t)(((idx[3] << 4) & 0xF0) | ((idx[4] >> 1) & 0xF)));
+    put(decoded, state, static_cast<uint8_t>(((idx[3] << 4) & 0xF0) | ((idx[4] >> 1) & 0xF)));
     if (idx_len == 5) {
         return;
     }
     // idx_len == 7: decoded size 4
-    put(decoded, state, (uint8_t)(((idx[4] << 7) & 0x80) | ((idx[5] << 2) & 0x7C) | ((idx[6] >> 3) & 0x3)));
+    put(decoded, state, static_cast<uint8_t>(((idx[4] << 7) & 0x80) | ((idx[5] << 2) & 0x7C) | ((idx[6] >> 3) & 0x3)));
 }
 
 } // namespace detail

--- a/cppcodec/detail/base64.hpp
+++ b/cppcodec/detail/base64.hpp
@@ -84,9 +84,9 @@ template <typename Result, typename ResultState>
 inline void base64<CodecVariant>::decode_block(
         Result& decoded, ResultState& state, const uint8_t* idx)
 {
-    data::put(decoded, state, (uint8_t)((idx[0] << 2) + ((idx[1] & 0x30) >> 4)));
-    data::put(decoded, state, (uint8_t)(((idx[1] & 0xF) << 4) + ((idx[2] & 0x3C) >> 2)));
-    data::put(decoded, state, (uint8_t)(((idx[2] & 0x3) << 6) + idx[3]));
+    data::put(decoded, state, static_cast<uint8_t>((idx[0] << 2) + ((idx[1] & 0x30) >> 4)));
+    data::put(decoded, state, static_cast<uint8_t>(((idx[1] & 0xF) << 4) + ((idx[2] & 0x3C) >> 2)));
+    data::put(decoded, state, static_cast<uint8_t>(((idx[2] & 0x3) << 6) + idx[3]));
 }
 
 template <typename CodecVariant>
@@ -100,13 +100,13 @@ inline void base64<CodecVariant>::decode_tail(
     }
 
     // idx_len == 2: decoded size 1
-    data::put(decoded, state, (uint8_t)((idx[0] << 2) + ((idx[1] & 0x30) >> 4)));
+    data::put(decoded, state, static_cast<uint8_t>((idx[0] << 2) + ((idx[1] & 0x30) >> 4)));
     if (idx_len == 2) {
         return;
     }
 
     // idx_len == 3: decoded size 2
-    data::put(decoded, state, (uint8_t)(((idx[1] & 0xF) << 4) + ((idx[2] & 0x3C) >> 2)));
+    data::put(decoded, state, static_cast<uint8_t>(((idx[1] & 0xF) << 4) + ((idx[2] & 0x3C) >> 2)));
 }
 
 } // namespace detail

--- a/cppcodec/detail/hex.hpp
+++ b/cppcodec/detail/hex.hpp
@@ -97,7 +97,7 @@ template <typename CodecVariant>
 template <typename Result, typename ResultState>
 inline void hex<CodecVariant>::decode_block(Result& decoded, ResultState& state, const uint8_t* idx)
 {
-    data::put(decoded, state, (uint8_t)((idx[0] << 4) | idx[1]));
+    data::put(decoded, state, static_cast<uint8_t>((idx[0] << 4) | idx[1]));
 }
 
 template <typename CodecVariant>

--- a/cppcodec/detail/stream_codec.hpp
+++ b/cppcodec/detail/stream_codec.hpp
@@ -90,7 +90,11 @@ struct enc {
         if (num_symbols == NumSymbols) {
             data::put(encoded, state, CodecVariant::symbol(Codec::template index_last<SymbolIndex>(src)));
             padder<CodecVariant::generates_padding()> pad;
+#ifdef _MSC_VER
+            pad.operator()<CodecVariant>(encoded, state, Codec::encoded_block_size() - NumSymbols);
+#else
             pad.template operator()<CodecVariant>(encoded, state, Codec::encoded_block_size() - NumSymbols);
+#endif
             return;
         }
         data::put(encoded, state, CodecVariant::symbol(Codec::template index<SymbolIndex>(src)));


### PR DESCRIPTION
I've included two commits, one for a VC14-specific workaround to make it compile, and another one for fixing warnings that showed up in my project because cppcodec used C-style casts.

The VC14-workaround may need additional attention in the future, in case a newer compiler shows a different behavior.
You can find the (huge) build log [here](https://gist.githubusercontent.com/thrimbor/7a67da3cd376daa2abbb6f947efdfdea/raw/7c87298889ce92524b064e2177b9a606a2f4e991/gistfile1.txt), test result is the following:

```
C:\Users\Venom\Desktop\cppcodec\build\test\Debug>test_cppcodec.exe
===============================================================================
All tests passed (514 assertions in 7 test cases)
```

I also checked compilation on my Arch Linux machine to make sure I didn't break anything, and it worked fine, too.