### PR TITLE
base64_default_url_unpadded was missing from cmake files list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(PUBLIC_HEADERS
     cppcodec/base32_rfc4648.hpp
     # base64
     cppcodec/base64_default_rfc4648.hpp
+    cppcodec/base64_default_url_unpadded.hpp
     cppcodec/base64_default_url.hpp
     cppcodec/base64_rfc4648.hpp
     cppcodec/base64_url.hpp


### PR DESCRIPTION
The `cppcodec/base64_default_url_unpadded.hpp` was missing from the FILES list in `CmakeLists.txt`. This caused this header to not be installed when `make install` is run.