### PR TITLE
Fix remaining VC14 warnings

### DIFF
--- a/cppcodec/detail/hex.hpp
+++ b/cppcodec/detail/hex.hpp
@@ -68,7 +68,9 @@ public:
 
     static CPPCODEC_ALWAYS_INLINE constexpr uint8_t num_encoded_tail_symbols(uint8_t /*num_bytes*/) noexcept
     {
-        return true ? 0 : throw std::domain_error("no tails in hex encoding, should never be called");
+        // Hex encoding only works on full bytes so there are no tails,
+        // no padding characters, and this function should (must) never be called.
+        return 0;
     }
 
     template <uint8_t I>

--- a/cppcodec/detail/hex.hpp
+++ b/cppcodec/detail/hex.hpp
@@ -71,18 +71,35 @@ public:
         return true ? 0 : throw std::domain_error("no tails in hex encoding, should never be called");
     }
 
-    template <uint8_t I> CPPCODEC_ALWAYS_INLINE static constexpr uint8_t index(
+    template <uint8_t I>
+    CPPCODEC_ALWAYS_INLINE static constexpr uint8_t index(
             const uint8_t* b /*binary block*/) noexcept
     {
+        static_assert(I >= 0 && I < encoded_block_size(),
+                "invalid encoding symbol index in a block");
+
         return (I == 0) ? (b[0] >> 4) // first 4 bits
-                : (I == 1) ? (b[0] & 0xF) // last 4 bits
-                : throw std::domain_error("invalid encoding symbol index in a block");
+                : /*I == 1*/ (b[0] & 0xF); // last 4 bits
     }
 
-        template <uint8_t I> CPPCODEC_ALWAYS_INLINE static constexpr uint8_t index_last(
-                const uint8_t* b /*binary block*/) noexcept
+    // With only 2 bytes, enc<1> will always result in a full index() call and
+    // enc<0> will be protected by a not-reached assertion, so we don't actually
+    // care about index_last() except optimizing it out as good as possible.
+    template <bool B>
+    using uint8_if = typename std::enable_if<B, uint8_t>::type;
+
+    template <uint8_t I>
+    CPPCODEC_ALWAYS_INLINE static constexpr uint8_if<I == 0> index_last(
+            const uint8_t* b /*binary block*/) noexcept
     {
-        return true ? 0 : throw std::domain_error("invalid last encoding symbol index in a tail");
+        return 0;
+    }
+
+    template <uint8_t I>
+    CPPCODEC_ALWAYS_INLINE static uint8_if<I != 0> index_last(
+            const uint8_t* b /*binary block*/)
+    {
+        throw std::domain_error("invalid last encoding symbol index in a tail");
     }
 
     template <typename Result, typename ResultState>


### PR DESCRIPTION
A bit of history: commit 5aedaa8 fixed most of issue #5 to make it work with VC14 and templatized much of the encoding functionality, leaving only `num_encoded_tail_symbols()`, `index()` and `index_tail()` to specify the codec-specific bitshifts for encoding each byte.

The thing about these functions is that in practice they're only called with valid values, but this is not necessarily easy to tell for the compiler. I kept the noexcept statements to document this to both users and compilers, and constexpr for potential future use in compile-time encoding, but I wanted to keep a last-resort error message in there to guard against potential misuse. C++11 allows throw expressions in constexpr functions as the only mechanism to fail, however when used with noexcept, compilers will complain that throw and noexcept don't go together and will result in program termination. This was in fact the desired behavior but causes unfortunate warnings. As a result, commit d471911 removed the noexcept statements.

So in this new version, I rewrote `index()` and `index_tail()` to distinguish between valid and invalid methods via template arguments. `index()` is only called on a contiguous range from 0 to `(encoded_block_size() - 1)` so it can use `static_assert()` to check for the right values. It would refuse to compile at all for invalid values. `index_tail()` is split into two implementations as the static template instantiation is imperfect, leaving holes of invalid values between valid ones. The function for valid values keeps constexpr and noexcept, whereas the one for invalid values removes them in favor of the old throw statement. Maybe in the future, static code generation can be refined to leave out the latter version.

Let's send it to Travis/AppVeyor and see if we get any other warnings instead.