### PR TITLE
Improve decoding performance by always inlining Codec::index_of()

### DIFF
--- a/cppcodec/base32_crockford.hpp
+++ b/cppcodec/base32_crockford.hpp
@@ -44,16 +44,16 @@ static_assert(sizeof(base32_crockford_alphabet) == 32, "base32 alphabet must hav
 class base32_crockford_base
 {
 public:
-    static inline constexpr bool generates_padding() { return false; }
-    static inline constexpr bool requires_padding() { return false; }
-    static inline constexpr bool is_padding_symbol(char /*c*/) { return false; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool generates_padding() { return false; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool requires_padding() { return false; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_padding_symbol(char /*c*/) { return false; }
 
-    static inline constexpr char symbol(uint8_t index)
+    static CPPCODEC_ALWAYS_INLINE constexpr char symbol(uint8_t index)
     {
         return base32_crockford_alphabet[index];
     }
 
-    static inline constexpr uint8_t index_of(char c)
+    static CPPCODEC_ALWAYS_INLINE constexpr uint8_t index_of(char c)
     {
         return (c >= '0' && c <= '9') ? (c - '0')
                 // upper-case letters
@@ -76,9 +76,9 @@ public:
                 : throw symbol_error(c);
     }
 
-    static inline constexpr bool should_ignore(uint8_t index) { return index == 253; }
-    static inline constexpr bool is_special_character(uint8_t index) { return index > 32; }
-    static inline constexpr bool is_eof(uint8_t index) { return index == 255; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool should_ignore(uint8_t index) { return index == 253; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_special_character(uint8_t index) { return index > 32; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_eof(uint8_t index) { return index == 255; }
 };
 
 // base32_crockford is a concatenative iterative (i.e. streaming) interpretation of Crockford base32.

--- a/cppcodec/base32_hex.hpp
+++ b/cppcodec/base32_hex.hpp
@@ -44,16 +44,16 @@ class base32_hex
 public:
     template <typename Codec> using codec_impl = stream_codec<Codec, base32_hex>;
 
-    static inline constexpr bool generates_padding() { return true; }
-    static inline constexpr bool requires_padding() { return true; }
-    static inline constexpr char padding_symbol() { return '='; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool generates_padding() { return true; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool requires_padding() { return true; }
+    static CPPCODEC_ALWAYS_INLINE constexpr char padding_symbol() { return '='; }
 
-    static inline constexpr char symbol(uint8_t index)
+    static CPPCODEC_ALWAYS_INLINE constexpr char symbol(uint8_t index)
     {
         return base32_hex_alphabet[index];
     }
 
-    static inline constexpr uint8_t index_of(char c)
+    static CPPCODEC_ALWAYS_INLINE constexpr uint8_t index_of(char c)
     {
         return (c >= '0' && c <= '9') ? (c - '0')
                 : (c >= 'A' && c <= 'V') ? (c - 'A' + 10)
@@ -64,10 +64,10 @@ public:
     }
 
     // RFC4648 does not specify any whitespace being allowed in base32 encodings.
-    static inline constexpr bool should_ignore(uint8_t /*index*/) { return false; }
-    static inline constexpr bool is_special_character(uint8_t index) { return index > 32; }
-    static inline constexpr bool is_padding_symbol(uint8_t index) { return index == 254; }
-    static inline constexpr bool is_eof(uint8_t index) { return index == 255; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool should_ignore(uint8_t /*index*/) { return false; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_special_character(uint8_t index) { return index > 32; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_padding_symbol(uint8_t index) { return index == 254; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_eof(uint8_t index) { return index == 255; }
 };
 
 } // namespace detail

--- a/cppcodec/base32_rfc4648.hpp
+++ b/cppcodec/base32_rfc4648.hpp
@@ -44,16 +44,16 @@ class base32_rfc4648
 public:
     template <typename Codec> using codec_impl = stream_codec<Codec, base32_rfc4648>;
 
-    static inline constexpr bool generates_padding() { return true; }
-    static inline constexpr bool requires_padding() { return true; }
-    static inline constexpr char padding_symbol() { return '='; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool generates_padding() { return true; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool requires_padding() { return true; }
+    static CPPCODEC_ALWAYS_INLINE constexpr char padding_symbol() { return '='; }
 
-    static inline constexpr char symbol(uint8_t index)
+    static CPPCODEC_ALWAYS_INLINE constexpr char symbol(uint8_t index)
     {
         return base32_rfc4648_alphabet[index];
     }
 
-    static inline constexpr uint8_t index_of(char c)
+    static CPPCODEC_ALWAYS_INLINE constexpr uint8_t index_of(char c)
     {
         return (c >= 'A' && c <= 'Z') ? (c - 'A')
                 : (c >= '2' && c <= '7') ? (c - '2' + 26)
@@ -64,10 +64,10 @@ public:
     }
 
     // RFC4648 does not specify any whitespace being allowed in base32 encodings.
-    static inline constexpr bool should_ignore(uint8_t /*index*/) { return false; }
-    static inline constexpr bool is_special_character(uint8_t index) { return index > 32; }
-    static inline constexpr bool is_padding_symbol(uint8_t index) { return index == 254; }
-    static inline constexpr bool is_eof(uint8_t index) { return index == 255; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool should_ignore(uint8_t /*index*/) { return false; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_special_character(uint8_t index) { return index > 32; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_padding_symbol(uint8_t index) { return index == 254; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_eof(uint8_t index) { return index == 255; }
 };
 
 } // namespace detail

--- a/cppcodec/base64_rfc4648.hpp
+++ b/cppcodec/base64_rfc4648.hpp
@@ -45,16 +45,16 @@ class base64_rfc4648
 public:
     template <typename Codec> using codec_impl = stream_codec<Codec, base64_rfc4648>;
 
-    static inline constexpr bool generates_padding() { return true; }
-    static inline constexpr bool requires_padding() { return true; }
-    static inline constexpr char padding_symbol() { return '='; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool generates_padding() { return true; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool requires_padding() { return true; }
+    static CPPCODEC_ALWAYS_INLINE constexpr char padding_symbol() { return '='; }
 
-    static inline constexpr char symbol(uint8_t index)
+    static CPPCODEC_ALWAYS_INLINE constexpr char symbol(uint8_t index)
     {
         return base64_rfc4648_alphabet[index];
     }
 
-    static inline constexpr uint8_t index_of(char c)
+    static CPPCODEC_ALWAYS_INLINE constexpr uint8_t index_of(char c)
     {
         return (c >= 'A' && c <= 'Z') ? (c - 'A')
                 : (c >= 'a' && c <= 'z') ? (c - 'a' + 26)
@@ -67,10 +67,10 @@ public:
     }
 
     // RFC4648 does not specify any whitespace being allowed in base64 encodings.
-    static inline constexpr bool should_ignore(uint8_t /*index*/) { return false; }
-    static inline constexpr bool is_special_character(uint8_t index) { return index > 64; }
-    static inline constexpr bool is_padding_symbol(uint8_t index) { return index == 254; }
-    static inline constexpr bool is_eof(uint8_t index) { return index == 255; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool should_ignore(uint8_t /*index*/) { return false; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_special_character(uint8_t index) { return index > 64; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_padding_symbol(uint8_t index) { return index == 254; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_eof(uint8_t index) { return index == 255; }
 };
 
 } // namespace detail

--- a/cppcodec/base64_url.hpp
+++ b/cppcodec/base64_url.hpp
@@ -47,16 +47,16 @@ class base64_url
 public:
     template <typename Codec> using codec_impl = stream_codec<Codec, base64_url>;
 
-    static inline constexpr bool generates_padding() { return true; }
-    static inline constexpr bool requires_padding() { return true; }
-    static inline constexpr char padding_symbol() { return '='; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool generates_padding() { return true; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool requires_padding() { return true; }
+    static CPPCODEC_ALWAYS_INLINE constexpr char padding_symbol() { return '='; }
 
-    static inline constexpr char symbol(uint8_t index)
+    static CPPCODEC_ALWAYS_INLINE constexpr char symbol(uint8_t index)
     {
         return base64_url_alphabet[index];
     }
 
-    static inline constexpr uint8_t index_of(char c)
+    static CPPCODEC_ALWAYS_INLINE constexpr uint8_t index_of(char c)
     {
         return (c >= 'A' && c <= 'Z') ? (c - 'A')
                 : (c >= 'a' && c <= 'z') ? (c - 'a' + 26)
@@ -69,10 +69,10 @@ public:
     }
 
     // RFC4648 does not specify any whitespace being allowed in base64 encodings.
-    static inline constexpr bool should_ignore(uint8_t /*index*/) { return false; }
-    static inline constexpr bool is_special_character(uint8_t index) { return index > 64; }
-    static inline constexpr bool is_padding_symbol(uint8_t index) { return index == 254; }
-    static inline constexpr bool is_eof(uint8_t index) { return index == 255; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool should_ignore(uint8_t /*index*/) { return false; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_special_character(uint8_t index) { return index > 64; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_padding_symbol(uint8_t index) { return index == 254; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_eof(uint8_t index) { return index == 255; }
 };
 
 } // namespace detail

--- a/cppcodec/base64_url_unpadded.hpp
+++ b/cppcodec/base64_url_unpadded.hpp
@@ -35,8 +35,8 @@ class base64_url_unpadded : public base64_url
 public:
     template <typename Codec> using codec_impl = stream_codec<Codec, base64_url_unpadded>;
 
-    static inline constexpr bool generates_padding() { return false; }
-    static inline constexpr bool requires_padding() { return false; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool generates_padding() { return false; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool requires_padding() { return false; }
 };
 
 } // namespace detail

--- a/cppcodec/hex_lower.hpp
+++ b/cppcodec/hex_lower.hpp
@@ -42,7 +42,7 @@ class hex_lower : public hex_base
 public:
     template <typename Codec> using codec_impl = stream_codec<Codec, hex_lower>;
 
-    static inline constexpr char symbol(uint8_t index)
+    static CPPCODEC_ALWAYS_INLINE constexpr char symbol(uint8_t index)
     {
         return hex_lower_alphabet[index];
     }

--- a/cppcodec/hex_upper.hpp
+++ b/cppcodec/hex_upper.hpp
@@ -42,7 +42,7 @@ class hex_upper : public hex_base
 public:
     template <typename Codec> using codec_impl = stream_codec<Codec, hex_upper>;
 
-    static inline constexpr char symbol(uint8_t index)
+    static CPPCODEC_ALWAYS_INLINE constexpr char symbol(uint8_t index)
     {
         return hex_upper_alphabet[index];
     }


### PR DESCRIPTION
In the gaspardpetit/base64 test, perf showed a significant amount
of time spent in that function, which seemed off because that
function should not exist at all in a release build.

Making sure it's inline reduces decoding time for Gaspard's 256
workload by almost 30% (from approx. 2.38 to 1.69 on my machine).
It seems logical to assume that other codecs get a similar
performance boost this way, so I'm applying the change everywhere.

This puts performance characteristics around the same level of
adamvr/arduino-base64 or the Manuel Martinez one (but without
the latter's apparent setup overhead). Still not the best,
but now definitely in the "fair" spectrum for decoding.