### PR TITLE
Make cppcodec runtime performance competitive

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-The MIT License (MIT)
-
-(See individual files for copyright holders.)
+Copyright (c) 2015 Topology Inc.
+Copyright (c) 2018 Jakob Petsovits
+Copyright (c) various other contributors, see individual files
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ and hex (a.k.a. base16) as specified in RFC 4648, plus Crockford's base32.
 
 MIT licensed with consistent, flexible API. Supports raw pointers,
 `std::string` and (templated) character vectors without unnecessary allocations.
+Cross-platform with measured decent performance and without compiler warnings.
 
 
 

--- a/cppcodec/base32_hex.hpp
+++ b/cppcodec/base32_hex.hpp
@@ -37,37 +37,34 @@ static constexpr const char base32_hex_alphabet[] = {
     'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K',
     'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V'
 };
-static_assert(sizeof(base32_hex_alphabet) == 32, "base32 alphabet must have 32 values");
 
 class base32_hex
 {
 public:
     template <typename Codec> using codec_impl = stream_codec<Codec, base32_hex>;
 
+    static CPPCODEC_ALWAYS_INLINE constexpr size_t alphabet_size() {
+        static_assert(sizeof(base32_hex_alphabet) == 32, "base32 alphabet must have 32 values");
+        return sizeof(base32_hex_alphabet);
+    }
+    static CPPCODEC_ALWAYS_INLINE constexpr char symbol(alphabet_index_t idx)
+    {
+        return base32_hex_alphabet[idx];
+    }
+    static CPPCODEC_ALWAYS_INLINE constexpr char normalized_symbol(char c)
+    {
+        // Lower-case letters are accepted, though not generally expected.
+        return (c >= 'a' && c <= 'v') ? (c - 'a' + 'A') : c;
+    }
+
     static CPPCODEC_ALWAYS_INLINE constexpr bool generates_padding() { return true; }
     static CPPCODEC_ALWAYS_INLINE constexpr bool requires_padding() { return true; }
     static CPPCODEC_ALWAYS_INLINE constexpr char padding_symbol() { return '='; }
-
-    static CPPCODEC_ALWAYS_INLINE constexpr char symbol(uint8_t index)
-    {
-        return base32_hex_alphabet[index];
-    }
-
-    static CPPCODEC_ALWAYS_INLINE constexpr uint8_t index_of(char c)
-    {
-        return (c >= '0' && c <= '9') ? (c - '0')
-                : (c >= 'A' && c <= 'V') ? (c - 'A' + 10)
-                : (c == padding_symbol()) ? 254
-                : (c == '\0') ? 255 // stop at end of string
-                : (c >= 'a' && c <= 'v') ? (c - 'a' + 10) // lower-case: not expected, but accepted
-                : throw symbol_error(c);
-    }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_padding_symbol(char c) { return c == '='; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_eof_symbol(char c) { return c == '\0'; }
 
     // RFC4648 does not specify any whitespace being allowed in base32 encodings.
-    static CPPCODEC_ALWAYS_INLINE constexpr bool should_ignore(uint8_t /*index*/) { return false; }
-    static CPPCODEC_ALWAYS_INLINE constexpr bool is_special_character(uint8_t index) { return index > 32; }
-    static CPPCODEC_ALWAYS_INLINE constexpr bool is_padding_symbol(uint8_t index) { return index == 254; }
-    static CPPCODEC_ALWAYS_INLINE constexpr bool is_eof(uint8_t index) { return index == 255; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool should_ignore(char) { return false; }
 };
 
 } // namespace detail

--- a/cppcodec/base32_rfc4648.hpp
+++ b/cppcodec/base32_rfc4648.hpp
@@ -37,37 +37,34 @@ static constexpr const char base32_rfc4648_alphabet[] = {
     'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', // at index 26
     '2', '3', '4', '5', '6', '7'
 };
-static_assert(sizeof(base32_rfc4648_alphabet) == 32, "base32 alphabet must have 32 values");
 
 class base32_rfc4648
 {
 public:
     template <typename Codec> using codec_impl = stream_codec<Codec, base32_rfc4648>;
 
+    static CPPCODEC_ALWAYS_INLINE constexpr size_t alphabet_size() {
+        static_assert(sizeof(base32_rfc4648_alphabet) == 32, "base32 alphabet must have 32 values");
+        return sizeof(base32_rfc4648_alphabet);
+    }
+    static CPPCODEC_ALWAYS_INLINE constexpr char symbol(alphabet_index_t idx)
+    {
+        return base32_rfc4648_alphabet[idx];
+    }
+    static CPPCODEC_ALWAYS_INLINE constexpr char normalized_symbol(char c)
+    {
+        // Lower-case letters are accepted, though not generally expected.
+        return (c >= 'a' && c <= 'z') ? (c - 'a' + 'A') : c;
+    }
+
     static CPPCODEC_ALWAYS_INLINE constexpr bool generates_padding() { return true; }
     static CPPCODEC_ALWAYS_INLINE constexpr bool requires_padding() { return true; }
     static CPPCODEC_ALWAYS_INLINE constexpr char padding_symbol() { return '='; }
-
-    static CPPCODEC_ALWAYS_INLINE constexpr char symbol(uint8_t index)
-    {
-        return base32_rfc4648_alphabet[index];
-    }
-
-    static CPPCODEC_ALWAYS_INLINE constexpr uint8_t index_of(char c)
-    {
-        return (c >= 'A' && c <= 'Z') ? (c - 'A')
-                : (c >= '2' && c <= '7') ? (c - '2' + 26)
-                : (c == padding_symbol()) ? 254
-                : (c == '\0') ? 255 // stop at end of string
-                : (c >= 'a' && c <= 'z') ? (c - 'a') // lower-case: not expected, but accepted
-                : throw symbol_error(c);
-    }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_padding_symbol(char c) { return c == '='; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_eof_symbol(char c) { return c == '\0'; }
 
     // RFC4648 does not specify any whitespace being allowed in base32 encodings.
-    static CPPCODEC_ALWAYS_INLINE constexpr bool should_ignore(uint8_t /*index*/) { return false; }
-    static CPPCODEC_ALWAYS_INLINE constexpr bool is_special_character(uint8_t index) { return index > 32; }
-    static CPPCODEC_ALWAYS_INLINE constexpr bool is_padding_symbol(uint8_t index) { return index == 254; }
-    static CPPCODEC_ALWAYS_INLINE constexpr bool is_eof(uint8_t index) { return index == 255; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool should_ignore(char) { return false; }
 };
 
 } // namespace detail

--- a/cppcodec/base64_rfc4648.hpp
+++ b/cppcodec/base64_rfc4648.hpp
@@ -38,39 +38,30 @@ static constexpr const char base64_rfc4648_alphabet[] = {
     'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
 };
-static_assert(sizeof(base64_rfc4648_alphabet) == 64, "base64 alphabet must have 64 values");
 
 class base64_rfc4648
 {
 public:
     template <typename Codec> using codec_impl = stream_codec<Codec, base64_rfc4648>;
 
+    static CPPCODEC_ALWAYS_INLINE constexpr size_t alphabet_size() {
+        static_assert(sizeof(base64_rfc4648_alphabet) == 64, "base64 alphabet must have 64 values");
+        return sizeof(base64_rfc4648_alphabet);
+    }
+    static CPPCODEC_ALWAYS_INLINE constexpr char symbol(alphabet_index_t idx)
+    {
+        return base64_rfc4648_alphabet[idx];
+    }
+    static CPPCODEC_ALWAYS_INLINE constexpr char normalized_symbol(char c) { return c; }
+
     static CPPCODEC_ALWAYS_INLINE constexpr bool generates_padding() { return true; }
     static CPPCODEC_ALWAYS_INLINE constexpr bool requires_padding() { return true; }
     static CPPCODEC_ALWAYS_INLINE constexpr char padding_symbol() { return '='; }
-
-    static CPPCODEC_ALWAYS_INLINE constexpr char symbol(uint8_t index)
-    {
-        return base64_rfc4648_alphabet[index];
-    }
-
-    static CPPCODEC_ALWAYS_INLINE constexpr uint8_t index_of(char c)
-    {
-        return (c >= 'A' && c <= 'Z') ? (c - 'A')
-                : (c >= 'a' && c <= 'z') ? (c - 'a' + 26)
-                : (c >= '0' && c <= '9') ? (c - '0' + 52)
-                : (c == '+') ? (c - '+' + 62)
-                : (c == '/') ? (c - '/' + 63)
-                : (c == padding_symbol()) ? 254
-                : (c == '\0') ? 255 // stop at end of string
-                : throw symbol_error(c);
-    }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_padding_symbol(char c) { return c == '='; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_eof_symbol(char c) { return c == '\0'; }
 
     // RFC4648 does not specify any whitespace being allowed in base64 encodings.
-    static CPPCODEC_ALWAYS_INLINE constexpr bool should_ignore(uint8_t /*index*/) { return false; }
-    static CPPCODEC_ALWAYS_INLINE constexpr bool is_special_character(uint8_t index) { return index > 64; }
-    static CPPCODEC_ALWAYS_INLINE constexpr bool is_padding_symbol(uint8_t index) { return index == 254; }
-    static CPPCODEC_ALWAYS_INLINE constexpr bool is_eof(uint8_t index) { return index == 255; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool should_ignore(char) { return false; }
 };
 
 } // namespace detail

--- a/cppcodec/base64_url.hpp
+++ b/cppcodec/base64_url.hpp
@@ -40,39 +40,30 @@ static constexpr const char base64_url_alphabet[] = {
     'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '_'
 };
-static_assert(sizeof(base64_url_alphabet) == 64, "base64 alphabet must have 64 values");
 
 class base64_url
 {
 public:
     template <typename Codec> using codec_impl = stream_codec<Codec, base64_url>;
 
+    static CPPCODEC_ALWAYS_INLINE constexpr size_t alphabet_size() {
+        static_assert(sizeof(base64_url_alphabet) == 64, "base64 alphabet must have 64 values");
+        return sizeof(base64_url_alphabet);
+    }
+    static CPPCODEC_ALWAYS_INLINE constexpr char symbol(alphabet_index_t idx)
+    {
+        return base64_url_alphabet[idx];
+    }
+    static CPPCODEC_ALWAYS_INLINE constexpr char normalized_symbol(char c) { return c; }
+
     static CPPCODEC_ALWAYS_INLINE constexpr bool generates_padding() { return true; }
     static CPPCODEC_ALWAYS_INLINE constexpr bool requires_padding() { return true; }
     static CPPCODEC_ALWAYS_INLINE constexpr char padding_symbol() { return '='; }
-
-    static CPPCODEC_ALWAYS_INLINE constexpr char symbol(uint8_t index)
-    {
-        return base64_url_alphabet[index];
-    }
-
-    static CPPCODEC_ALWAYS_INLINE constexpr uint8_t index_of(char c)
-    {
-        return (c >= 'A' && c <= 'Z') ? (c - 'A')
-                : (c >= 'a' && c <= 'z') ? (c - 'a' + 26)
-                : (c >= '0' && c <= '9') ? (c - '0' + 52)
-                : (c == '-') ? (c - '-' + 62)
-                : (c == '_') ? (c - '_' + 63)
-                : (c == padding_symbol()) ? 254
-                : (c == '\0') ? 255 // stop at end of string
-                : throw symbol_error(c);
-    }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_padding_symbol(char c) { return c == '='; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_eof_symbol(char c) { return c == '\0'; }
 
     // RFC4648 does not specify any whitespace being allowed in base64 encodings.
-    static CPPCODEC_ALWAYS_INLINE constexpr bool should_ignore(uint8_t /*index*/) { return false; }
-    static CPPCODEC_ALWAYS_INLINE constexpr bool is_special_character(uint8_t index) { return index > 64; }
-    static CPPCODEC_ALWAYS_INLINE constexpr bool is_padding_symbol(uint8_t index) { return index == 254; }
-    static CPPCODEC_ALWAYS_INLINE constexpr bool is_eof(uint8_t index) { return index == 255; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool should_ignore(char) { return false; }
 };
 
 } // namespace detail

--- a/cppcodec/data/access.hpp
+++ b/cppcodec/data/access.hpp
@@ -264,16 +264,16 @@ CPPCODEC_ALWAYS_INLINE array_access_result_state<Result> create_state(Result&, s
     return array_access_result_state<Result>();
 }
 
-#if __cplusplus < 201703L
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG > 201703L)
+static_assert(std::is_same<
+    decltype(create_state(*(std::string*)nullptr, specific_t())),
+    direct_data_access_result_state<std::string>>::value,
+    "std::string (C++17 and later) must be handled by direct_data_access_result_state");
+#elif __cplusplus < 201703 && !defined(_MSVC_LANG) // we can't trust MSVC to set this right
 static_assert(std::is_same<
         decltype(create_state(*(std::string*)nullptr, specific_t())),
         array_access_result_state<std::string>>::value,
         "std::string (pre-C++17) must be handled by array_access_result_state");
-#else
-static_assert(std::is_same<
-        decltype(create_state(*(std::string*)nullptr, specific_t())),
-        direct_data_access_result_state<std::string>>::value,
-        "std::string (C++17 and later) must be handled by direct_data_access_result_state");
 #endif
 
 // Specialized init(), put() and finish() functions for array_access_result_state.

--- a/cppcodec/detail/base32.hpp
+++ b/cppcodec/detail/base32.hpp
@@ -59,7 +59,7 @@ public:
     }
 
     template <uint8_t I>
-    CPPCODEC_ALWAYS_INLINE static constexpr uint8_t index(
+    static CPPCODEC_ALWAYS_INLINE constexpr uint8_t index(
             const uint8_t* b /*binary block*/) noexcept
     {
         static_assert(I >= 0 && I < encoded_block_size(),
@@ -79,7 +79,7 @@ public:
     using uint8_if = typename std::enable_if<B, uint8_t>::type;
 
     template <uint8_t I>
-    CPPCODEC_ALWAYS_INLINE static constexpr
+    static CPPCODEC_ALWAYS_INLINE constexpr
     uint8_if<I == 1 || I == 3 || I == 4 || I == 6> index_last(
             const uint8_t* b /*binary block*/) noexcept
     {
@@ -90,7 +90,7 @@ public:
     }
 
     template <uint8_t I>
-    CPPCODEC_ALWAYS_INLINE static
+    static CPPCODEC_ALWAYS_INLINE
     uint8_if<I != 1 && I != 3 && I != 4 && I != 6> index_last(
             const uint8_t* b /*binary block*/)
     {
@@ -98,10 +98,12 @@ public:
     }
 
     template <typename Result, typename ResultState>
-    static void decode_block(Result& decoded, ResultState&, const uint8_t* idx);
+    static CPPCODEC_ALWAYS_INLINE void decode_block(
+            Result& decoded, ResultState&, const alphabet_index_t* idx);
 
     template <typename Result, typename ResultState>
-    static void decode_tail(Result& decoded, ResultState&, const uint8_t* idx, size_t idx_len);
+    static CPPCODEC_ALWAYS_INLINE void decode_tail(
+            Result& decoded, ResultState&, const alphabet_index_t* idx, size_t idx_len);
 };
 
 //
@@ -111,8 +113,8 @@ public:
 
 template <typename CodecVariant>
 template <typename Result, typename ResultState>
-inline void base32<CodecVariant>::decode_block(
-        Result& decoded, ResultState& state, const uint8_t* idx)
+CPPCODEC_ALWAYS_INLINE void base32<CodecVariant>::decode_block(
+        Result& decoded, ResultState& state, const alphabet_index_t* idx)
 {
     put(decoded, state, static_cast<uint8_t>(((idx[0] << 3) & 0xF8) | ((idx[1] >> 2) & 0x7)));
     put(decoded, state, static_cast<uint8_t>(((idx[1] << 6) & 0xC0) | ((idx[2] << 1) & 0x3E) | ((idx[3] >> 4) & 0x1)));
@@ -123,8 +125,8 @@ inline void base32<CodecVariant>::decode_block(
 
 template <typename CodecVariant>
 template <typename Result, typename ResultState>
-inline void base32<CodecVariant>::decode_tail(
-        Result& decoded, ResultState& state, const uint8_t* idx, size_t idx_len)
+CPPCODEC_ALWAYS_INLINE void base32<CodecVariant>::decode_tail(
+        Result& decoded, ResultState& state, const alphabet_index_t* idx, size_t idx_len)
 {
     if (idx_len == 1) {
         throw invalid_input_length(

--- a/cppcodec/detail/config.hpp
+++ b/cppcodec/detail/config.hpp
@@ -30,6 +30,8 @@
 
 #if __GNUC__ || __has_attribute(always_inline)
 #define CPPCODEC_ALWAYS_INLINE inline __attribute__((always_inline))
+#elif defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#define CPPCODEC_ALWAYS_INLINE inline __forceinline
 #else
 #define CPPCODEC_ALWAYS_INLINE inline
 #endif

--- a/cppcodec/detail/hex.hpp
+++ b/cppcodec/detail/hex.hpp
@@ -35,31 +35,6 @@
 namespace cppcodec {
 namespace detail {
 
-class hex_base
-{
-public:
-    static inline constexpr uint8_t index_of(char c)
-    {
-        // Hex decoding is always case-insensitive (even in RFC 4648),
-        // it's only a question of what we want to encode ourselves.
-        return (c >= '0' && c <= '9') ? (c - '0')
-                : (c >= 'A' && c <= 'F') ? (c - 'A' + 10)
-                : (c >= 'a' && c <= 'f') ? (c - 'a' + 10)
-                : (c == '\0') ? 255 // stop at end of string
-                : throw symbol_error(c);
-    }
-
-    // RFC4648 does not specify any whitespace being allowed in base64 encodings.
-    static inline constexpr bool should_ignore(uint8_t /*index*/) { return false; }
-    static inline constexpr bool is_special_character(uint8_t index) { return index > 64; }
-    static inline constexpr bool is_eof(uint8_t index) { return index == 255; }
-
-    static inline constexpr bool generates_padding() { return false; }
-    // FIXME: doesn't require padding, but requires a multiple of the encoded block size (2)
-    static inline constexpr bool requires_padding() { return false; }
-    static inline constexpr bool is_padding_symbol(uint8_t /*index*/) { return false; }
-};
-
 template <typename CodecVariant>
 class hex : public CodecVariant::template codec_impl<hex<CodecVariant>>
 {
@@ -75,7 +50,7 @@ public:
     }
 
     template <uint8_t I>
-    CPPCODEC_ALWAYS_INLINE static constexpr uint8_t index(
+    static CPPCODEC_ALWAYS_INLINE constexpr uint8_t index(
             const uint8_t* b /*binary block*/) noexcept
     {
         static_assert(I >= 0 && I < encoded_block_size(),
@@ -92,37 +67,41 @@ public:
     using uint8_if = typename std::enable_if<B, uint8_t>::type;
 
     template <uint8_t I>
-    CPPCODEC_ALWAYS_INLINE static constexpr uint8_if<I == 0> index_last(
+    static CPPCODEC_ALWAYS_INLINE constexpr uint8_if<I == 0> index_last(
             const uint8_t* b /*binary block*/) noexcept
     {
         return 0;
     }
 
     template <uint8_t I>
-    CPPCODEC_ALWAYS_INLINE static uint8_if<I != 0> index_last(
+    static CPPCODEC_ALWAYS_INLINE uint8_if<I != 0> index_last(
             const uint8_t* b /*binary block*/)
     {
         throw std::domain_error("invalid last encoding symbol index in a tail");
     }
 
     template <typename Result, typename ResultState>
-    static void decode_block(Result& decoded, ResultState&, const uint8_t* idx);
+    static CPPCODEC_ALWAYS_INLINE void decode_block(
+            Result& decoded, ResultState&, const alphabet_index_t* idx);
 
     template <typename Result, typename ResultState>
-    static void decode_tail(Result& decoded, ResultState&, const uint8_t* idx, size_t idx_len);
+    static CPPCODEC_ALWAYS_INLINE void decode_tail(
+            Result& decoded, ResultState&, const alphabet_index_t* idx, size_t idx_len);
 };
 
 
 template <typename CodecVariant>
 template <typename Result, typename ResultState>
-inline void hex<CodecVariant>::decode_block(Result& decoded, ResultState& state, const uint8_t* idx)
+CPPCODEC_ALWAYS_INLINE void hex<CodecVariant>::decode_block(
+        Result& decoded, ResultState& state, const alphabet_index_t* idx)
 {
     data::put(decoded, state, static_cast<uint8_t>((idx[0] << 4) | idx[1]));
 }
 
 template <typename CodecVariant>
 template <typename Result, typename ResultState>
-inline void hex<CodecVariant>::decode_tail(Result&, ResultState&, const uint8_t*, size_t)
+CPPCODEC_ALWAYS_INLINE void hex<CodecVariant>::decode_tail(
+        Result&, ResultState&, const alphabet_index_t*, size_t)
 {
     throw invalid_input_length(
             "odd-length hex input is not supported by the streaming octet decoder, "

--- a/cppcodec/detail/stream_codec.hpp
+++ b/cppcodec/detail/stream_codec.hpp
@@ -1,5 +1,6 @@
 /**
  *  Copyright (C) 2015 Topology LP
+ *  Copyright (C) 2018 Jakob Petsovits
  *  All rights reserved.
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -24,6 +25,7 @@
 #ifndef CPPCODEC_DETAIL_STREAM_CODEC
 #define CPPCODEC_DETAIL_STREAM_CODEC
 
+#include <limits>
 #include <stdlib.h> // for abort()
 #include <stdint.h>
 
@@ -32,6 +34,8 @@
 
 namespace cppcodec {
 namespace detail {
+
+using alphabet_index_t = uint_fast16_t;
 
 template <typename Codec, typename CodecVariant>
 class stream_codec
@@ -104,7 +108,6 @@ struct enc {
 
 template<> // terminating specialization
 struct enc<0> {
-
     template <typename Codec, typename CodecVariant, typename Result, typename ResultState>
     static CPPCODEC_ALWAYS_INLINE void block(Result&, ResultState&, const uint8_t*) { }
 
@@ -146,68 +149,250 @@ inline void stream_codec<Codec, CodecVariant>::encode(
     }
 }
 
+// Range & lookup table generation, see
+// http://stackoverflow.com/questions/13313980/populate-an-array-using-constexpr-at-compile-time
+// and http://cplusadd.blogspot.ca/2013/02/c11-compile-time-lookup-tablearray-with.html
+
+template<unsigned... Is> struct seq {};
+
+template<unsigned N, unsigned... Is>
+struct gen_seq : gen_seq<N - 4, N - 4, N - 3, N - 2, N - 1, Is...> {
+    // Clang up to 3.6 has a limit of 256 for template recursion,
+    // so pass a few more symbols at once to make it work.
+    static_assert(N % 4 == 0, "I must be divisible by 4 to eventually end at 0");
+};
+template<unsigned... Is>
+struct gen_seq<0, Is...> : seq<Is...> {};
+
+template <size_t N>
+struct lookup_table_t {
+    alphabet_index_t lookup[N];
+    static constexpr size_t size = N;
+};
+
+template<typename LambdaType, unsigned... Is>
+constexpr lookup_table_t<sizeof...(Is)> make_lookup_table(seq<Is...>, LambdaType value_for_index) {
+    return { { value_for_index(Is)... } };
+}
+
+template<unsigned N, typename LambdaType>
+constexpr lookup_table_t<N> make_lookup_table(LambdaType evalFunc) {
+    return make_lookup_table(gen_seq<N>(), evalFunc);
+}
+
+// CodecVariant::symbol() provides a symbol for an index.
+// Use recursive templates to get the inverse lookup table for fast decoding.
+
+template <typename T>
+static CPPCODEC_ALWAYS_INLINE constexpr size_t num_possible_values()
+{
+    return static_cast<size_t>(
+            static_cast<intmax_t>(std::numeric_limits<T>::max())
+                    - static_cast<intmax_t>(std::numeric_limits<T>::min()) + 1);
+}
+
+template <typename CodecVariant, alphabet_index_t InvalidIdx, size_t I>
+struct index_if_in_alphabet {
+    static CPPCODEC_ALWAYS_INLINE constexpr alphabet_index_t for_symbol(char symbol)
+    {
+        return (CodecVariant::symbol(
+                    static_cast<alphabet_index_t>(CodecVariant::alphabet_size() - I)) == symbol)
+            ? static_cast<alphabet_index_t>(CodecVariant::alphabet_size() - I)
+            : index_if_in_alphabet<CodecVariant, InvalidIdx, I - 1>::for_symbol(symbol);
+    }
+};
+template <typename CodecVariant, alphabet_index_t InvalidIdx>
+struct index_if_in_alphabet<CodecVariant, InvalidIdx, 0> { // terminating specialization
+    static CPPCODEC_ALWAYS_INLINE constexpr alphabet_index_t for_symbol(char symbol)
+    {
+        return InvalidIdx;
+    }
+};
+
+template <typename CodecVariant, size_t I>
+struct padding_searcher {
+    static CPPCODEC_ALWAYS_INLINE constexpr bool exists_padding_symbol()
+    {
+        // Clang up to 3.6 has a limit of 256 for template recursion,
+        // so pass a few more symbols at once to make it work.
+        static_assert(I % 4 == 0, "I must be divisible by 4 to eventually end at 0");
+
+        return CodecVariant::is_padding_symbol(
+                        static_cast<char>(num_possible_values<char>() - I - 4))
+                || CodecVariant::is_padding_symbol(
+                        static_cast<char>(num_possible_values<char>() - I - 3))
+                || CodecVariant::is_padding_symbol(
+                        static_cast<char>(num_possible_values<char>() - I - 2))
+                || CodecVariant::is_padding_symbol(
+                        static_cast<char>(num_possible_values<char>() - I - 1))
+                || padding_searcher<CodecVariant, I - 4>::exists_padding_symbol();
+    }
+};
+template <typename CodecVariant>
+struct padding_searcher<CodecVariant, 0> { // terminating specialization
+    static CPPCODEC_ALWAYS_INLINE constexpr bool exists_padding_symbol() { return false; }
+};
+
+template <typename CodecVariant>
+struct alphabet_index_info
+{
+    static constexpr const size_t num_possible_symbols = num_possible_values<char>();
+
+    static constexpr const alphabet_index_t padding_idx = 1 << 8;
+    static constexpr const alphabet_index_t invalid_idx = 1 << 9;
+    static constexpr const alphabet_index_t eof_idx = 1 << 10;
+    static constexpr const alphabet_index_t stop_character_mask = ~0xFF;
+
+    static constexpr const bool padding_allowed = padding_searcher<
+            CodecVariant, num_possible_symbols>::exists_padding_symbol();
+
+    static CPPCODEC_ALWAYS_INLINE constexpr bool allows_padding()
+    {
+        return padding_allowed;
+    }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_padding(alphabet_index_t idx)
+    {
+        return allows_padding() ? (idx == padding_idx) : false;
+    }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_invalid(alphabet_index_t idx) { return idx == invalid_idx; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_eof(alphabet_index_t idx) { return idx == eof_idx; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_stop_character(alphabet_index_t idx)
+    {
+        return (idx & stop_character_mask) != 0;
+    }
+
+private:
+    static CPPCODEC_ALWAYS_INLINE constexpr
+    alphabet_index_t valid_index_or(alphabet_index_t a, alphabet_index_t b)
+    {
+        return a == invalid_idx ? b : a;
+    }
+
+    using idx_if_in_alphabet = index_if_in_alphabet<
+            CodecVariant, invalid_idx, CodecVariant::alphabet_size()>;
+
+    static CPPCODEC_ALWAYS_INLINE constexpr alphabet_index_t index_of(char symbol)
+    {
+        return valid_index_or(idx_if_in_alphabet::for_symbol(symbol),
+            CodecVariant::is_eof_symbol(symbol) ? eof_idx
+            : CodecVariant::is_padding_symbol(symbol) ? padding_idx
+            : invalid_idx);
+    }
+
+    // GCC <= 4.9 has a bug with retaining constexpr when passing a function pointer.
+    // To get around this, we'll create a callable with operator() and pass that one.
+    // Unfortunately, MSVC prior to VS 2017 (for MinSizeRel or Release builds)
+    // chokes on this by compiling the project in 20 minutes instead of seconds.
+    // So let's define two separate variants and remove the old GCC one whenever we
+    // decide not to support GCC < 5.0 anymore.
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5
+    struct index_at {
+        CPPCODEC_ALWAYS_INLINE constexpr alphabet_index_t operator()(size_t symbol) const {
+            return index_of(CodecVariant::normalized_symbol(static_cast<char>(symbol)));
+        }
+    };
+#else
+    static CPPCODEC_ALWAYS_INLINE constexpr alphabet_index_t index_at(size_t symbol)
+    {
+        return index_of(CodecVariant::normalized_symbol(static_cast<char>(symbol)));
+    }
+#endif
+
+public:
+    struct lookup {
+        static CPPCODEC_ALWAYS_INLINE alphabet_index_t for_symbol(char symbol)
+        {
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5
+            static constexpr const auto t = make_lookup_table<num_possible_symbols>(index_at());
+#else
+            static constexpr const auto t = make_lookup_table<num_possible_symbols>(&index_at);
+#endif
+            static_assert(t.size == num_possible_symbols,
+                    "lookup table must cover each possible (character) symbol");
+            return t.lookup[static_cast<uint8_t>(symbol)];
+        }
+    };
+};
+
+//
+// At long last! The actual decode/encode functions.
+
 template <typename Codec, typename CodecVariant>
 template <typename Result, typename ResultState>
 inline void stream_codec<Codec, CodecVariant>::decode(
         Result& binary_result, ResultState& state,
         const char* src_encoded, size_t src_size)
 {
+    using alphabet_index_lookup = typename alphabet_index_info<CodecVariant>::lookup;
     const char* src = src_encoded;
     const char* src_end = src + src_size;
 
-    uint8_t idx[Codec::encoded_block_size()] = {};
-    uint8_t last_value_idx = 0;
+    alphabet_index_t alphabet_indexes[Codec::encoded_block_size()] = {};
+    alphabet_index_t current_alphabet_index = alphabet_index_info<CodecVariant>::eof_idx;
+    size_t current_block_index = 0;
 
     while (src < src_end) {
-        if (CodecVariant::should_ignore(idx[last_value_idx] = CodecVariant::index_of(*(src++)))) {
+        if (CodecVariant::should_ignore(*src)) {
+            ++src;
             continue;
         }
-        if (CodecVariant::is_special_character(idx[last_value_idx])) {
+        current_alphabet_index = alphabet_index_lookup::for_symbol(*src);
+        if (alphabet_index_info<CodecVariant>::is_stop_character(current_alphabet_index)) {
             break;
         }
+        ++src;
+        alphabet_indexes[current_block_index++] = current_alphabet_index;
 
-        ++last_value_idx;
-        if (last_value_idx == Codec::encoded_block_size()) {
-            Codec::decode_block(binary_result, state, idx);
-            last_value_idx = 0;
+        if (current_block_index == Codec::encoded_block_size()) {
+            Codec::decode_block(binary_result, state, alphabet_indexes);
+            current_block_index = 0;
         }
     }
 
-    uint8_t last_idx = last_value_idx;
-    if (CodecVariant::is_padding_symbol(idx[last_value_idx])) {
-        if (!last_value_idx) {
+    if (alphabet_index_info<CodecVariant>::is_invalid(current_alphabet_index)) {
+        throw symbol_error(*src);
+    }
+    ++src;
+
+    size_t last_block_index = current_block_index;
+    if (alphabet_index_info<CodecVariant>::is_padding(current_alphabet_index)) {
+        if (current_block_index == 0) {
             // Don't accept padding at the start of a block.
             // The encoder should have omitted that padding altogether.
             throw padding_error();
         }
         // We're in here because we just read a (first) padding character. Try to read more.
-        ++last_idx;
+        ++last_block_index;
         while (src < src_end) {
-            // Use idx[last_value_idx] to avoid declaring another uint8_t. It's unused now so that's okay.
-            if (CodecVariant::is_eof(idx[last_value_idx] = CodecVariant::index_of(*(src++)))) {
+            alphabet_index_t last_alphabet_index = alphabet_index_lookup::for_symbol(*(src++));
+
+            if (alphabet_index_info<CodecVariant>::is_eof(last_alphabet_index)) {
                 break;
             }
-            if (!CodecVariant::is_padding_symbol(idx[last_value_idx])) {
+            if (!alphabet_index_info<CodecVariant>::is_padding(last_alphabet_index)) {
                 throw padding_error();
             }
 
-            ++last_idx;
-            if (last_idx > Codec::encoded_block_size()) {
+            ++last_block_index;
+            if (last_block_index > Codec::encoded_block_size()) {
                 throw padding_error();
             }
         }
     }
 
-    if (last_idx)  {
-        if (CodecVariant::requires_padding() && last_idx != Codec::encoded_block_size()) {
+    if (last_block_index)  {
+        if ((CodecVariant::requires_padding()
+                    || alphabet_index_info<CodecVariant>::is_padding(current_alphabet_index)
+                    ) && last_block_index != Codec::encoded_block_size())
+        {
             // If the input is not a multiple of the block size then the input is incorrect.
             throw padding_error();
         }
-        if (last_value_idx >= Codec::encoded_block_size()) {
+        if (current_block_index >= Codec::encoded_block_size()) {
             abort();
             return;
         }
-        Codec::decode_tail(binary_result, state, idx, last_value_idx);
+        Codec::decode_tail(binary_result, state, alphabet_indexes, current_block_index);
     }
 }
 

--- a/cppcodec/detail/stream_codec.hpp
+++ b/cppcodec/detail/stream_codec.hpp
@@ -328,71 +328,78 @@ inline void stream_codec<Codec, CodecVariant>::decode(
     const char* src_end = src + src_size;
 
     alphabet_index_t alphabet_indexes[Codec::encoded_block_size()] = {};
-    alphabet_index_t current_alphabet_index = alphabet_index_info<CodecVariant>::eof_idx;
-    size_t current_block_index = 0;
+    alphabet_indexes[0] = alphabet_index_info<CodecVariant>::eof_idx;
+
+    alphabet_index_t* const alphabet_index_start = &alphabet_indexes[0];
+    alphabet_index_t* const alphabet_index_end = &alphabet_indexes[Codec::encoded_block_size()];
+    alphabet_index_t* alphabet_index_ptr = &alphabet_indexes[0];
 
     while (src < src_end) {
         if (CodecVariant::should_ignore(*src)) {
             ++src;
             continue;
         }
-        current_alphabet_index = alphabet_index_lookup::for_symbol(*src);
-        if (alphabet_index_info<CodecVariant>::is_stop_character(current_alphabet_index)) {
+        *alphabet_index_ptr = alphabet_index_lookup::for_symbol(*src);
+        if (alphabet_index_info<CodecVariant>::is_stop_character(*alphabet_index_ptr)) {
             break;
         }
         ++src;
-        alphabet_indexes[current_block_index++] = current_alphabet_index;
+        ++alphabet_index_ptr;
 
-        if (current_block_index == Codec::encoded_block_size()) {
+        if (alphabet_index_ptr == alphabet_index_end) {
             Codec::decode_block(binary_result, state, alphabet_indexes);
-            current_block_index = 0;
+            alphabet_index_ptr = alphabet_index_start;
         }
     }
 
-    if (alphabet_index_info<CodecVariant>::is_invalid(current_alphabet_index)) {
+    if (alphabet_index_info<CodecVariant>::is_invalid(*alphabet_index_ptr)) {
         throw symbol_error(*src);
     }
     ++src;
 
-    size_t last_block_index = current_block_index;
-    if (alphabet_index_info<CodecVariant>::is_padding(current_alphabet_index)) {
-        if (current_block_index == 0) {
+    alphabet_index_t* last_index_ptr = alphabet_index_ptr;
+    if (alphabet_index_info<CodecVariant>::is_padding(*last_index_ptr)) {
+        if (last_index_ptr == alphabet_index_start) {
             // Don't accept padding at the start of a block.
             // The encoder should have omitted that padding altogether.
             throw padding_error();
         }
         // We're in here because we just read a (first) padding character. Try to read more.
-        ++last_block_index;
+        // Count with last_index_ptr, but store in alphabet_index_ptr so we don't
+        // overflow the array in case the input data is too long.
+        ++last_index_ptr;
         while (src < src_end) {
-            alphabet_index_t last_alphabet_index = alphabet_index_lookup::for_symbol(*(src++));
+            *alphabet_index_ptr = alphabet_index_lookup::for_symbol(*(src++));
 
-            if (alphabet_index_info<CodecVariant>::is_eof(last_alphabet_index)) {
+            if (alphabet_index_info<CodecVariant>::is_eof(*alphabet_index_ptr)) {
+                *alphabet_index_ptr = alphabet_index_info<CodecVariant>::padding_idx;
                 break;
             }
-            if (!alphabet_index_info<CodecVariant>::is_padding(last_alphabet_index)) {
+            if (!alphabet_index_info<CodecVariant>::is_padding(*alphabet_index_ptr)) {
                 throw padding_error();
             }
 
-            ++last_block_index;
-            if (last_block_index > Codec::encoded_block_size()) {
+            ++last_index_ptr;
+            if (last_index_ptr > alphabet_index_end) {
                 throw padding_error();
             }
         }
     }
 
-    if (last_block_index)  {
+    if (last_index_ptr != alphabet_index_start)  {
         if ((CodecVariant::requires_padding()
-                    || alphabet_index_info<CodecVariant>::is_padding(current_alphabet_index)
-                    ) && last_block_index != Codec::encoded_block_size())
+                    || alphabet_index_info<CodecVariant>::is_padding(*alphabet_index_ptr)
+                    ) && last_index_ptr != alphabet_index_end)
         {
             // If the input is not a multiple of the block size then the input is incorrect.
             throw padding_error();
         }
-        if (current_block_index >= Codec::encoded_block_size()) {
+        if (alphabet_index_ptr >= alphabet_index_end) {
             abort();
             return;
         }
-        Codec::decode_tail(binary_result, state, alphabet_indexes, current_block_index);
+        Codec::decode_tail(binary_result, state, alphabet_indexes,
+                static_cast<size_t>(alphabet_index_ptr - alphabet_index_start));
     }
 }
 

--- a/cppcodec/hex_lower.hpp
+++ b/cppcodec/hex_lower.hpp
@@ -35,17 +35,35 @@ static constexpr const char hex_lower_alphabet[] = {
         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', // at index 10
         'a', 'b', 'c', 'd', 'e', 'f'
 };
-static_assert(sizeof(hex_lower_alphabet) == 16, "hex alphabet must have 16 values");
 
-class hex_lower : public hex_base
+class hex_lower
 {
 public:
     template <typename Codec> using codec_impl = stream_codec<Codec, hex_lower>;
 
-    static CPPCODEC_ALWAYS_INLINE constexpr char symbol(uint8_t index)
+    static CPPCODEC_ALWAYS_INLINE constexpr size_t alphabet_size() {
+        static_assert(sizeof(hex_lower_alphabet) == 16, "hex alphabet must have 16 values");
+        return sizeof(hex_lower_alphabet);
+    }
+    static CPPCODEC_ALWAYS_INLINE constexpr char symbol(alphabet_index_t index)
     {
         return hex_lower_alphabet[index];
     }
+    static CPPCODEC_ALWAYS_INLINE constexpr char normalized_symbol(char c)
+    {
+        // Hex decoding is always case-insensitive (even in RFC 4648), the question
+        // is only for encoding whether to use upper-case or lower-case letters.
+        return (c >= 'A' && c <= 'F') ? (c - 'A' + 'a') : c;
+    }
+
+    static CPPCODEC_ALWAYS_INLINE constexpr bool generates_padding() { return false; }
+    // FIXME: doesn't require padding, but requires a multiple of the encoded block size (2)
+    static CPPCODEC_ALWAYS_INLINE constexpr bool requires_padding() { return false; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_padding_symbol(char c) { return false; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_eof_symbol(char c) { return c == '\0'; }
+
+    // Sometimes hex strings include whitespace, but this variant forbids it.
+    static CPPCODEC_ALWAYS_INLINE constexpr bool should_ignore(char) { return false; }
 };
 
 } // namespace detail

--- a/cppcodec/hex_upper.hpp
+++ b/cppcodec/hex_upper.hpp
@@ -35,17 +35,35 @@ static constexpr const char hex_upper_alphabet[] = {
         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
         'A', 'B', 'C', 'D', 'E', 'F'
 };
-static_assert(sizeof(hex_upper_alphabet) == 16, "hex alphabet must have 16 values");
 
-class hex_upper : public hex_base
+class hex_upper
 {
 public:
     template <typename Codec> using codec_impl = stream_codec<Codec, hex_upper>;
 
-    static CPPCODEC_ALWAYS_INLINE constexpr char symbol(uint8_t index)
+    static CPPCODEC_ALWAYS_INLINE constexpr size_t alphabet_size() {
+        static_assert(sizeof(hex_upper_alphabet) == 16, "hex alphabet must have 16 values");
+        return sizeof(hex_upper_alphabet);
+    }
+    static CPPCODEC_ALWAYS_INLINE constexpr char symbol(alphabet_index_t index)
     {
         return hex_upper_alphabet[index];
     }
+    static CPPCODEC_ALWAYS_INLINE constexpr char normalized_symbol(char c)
+    {
+        // Hex decoding is always case-insensitive (even in RFC 4648), the question
+        // is only for encoding whether to use upper-case or lower-case letters.
+        return (c >= 'a' && c <= 'f') ? (c - 'a' + 'A') : c;
+    }
+
+    static CPPCODEC_ALWAYS_INLINE constexpr bool generates_padding() { return false; }
+    // FIXME: doesn't require padding, but requires a multiple of the encoded block size (2)
+    static CPPCODEC_ALWAYS_INLINE constexpr bool requires_padding() { return false; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_padding_symbol(char c) { return false; }
+    static CPPCODEC_ALWAYS_INLINE constexpr bool is_eof_symbol(char c) { return c == '\0'; }
+
+    // Sometimes hex strings include whitespace, but this variant forbids it.
+    static CPPCODEC_ALWAYS_INLINE constexpr bool should_ignore(char) { return false; }
 };
 
 } // namespace detail

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,3 +18,5 @@ add_executable(test_cppcodec test_cppcodec.cpp)
 add_test(cppcodec test_cppcodec)
 
 add_executable(benchmark_cppcodec benchmark_cppcodec.cpp)
+
+add_executable(minimal_decode minimal_decode.cpp)

--- a/test/minimal_decode.cpp
+++ b/test/minimal_decode.cpp
@@ -1,0 +1,34 @@
+/**
+*  Copyright (C) 2018 Jakob Petsovits
+*  All rights reserved.
+*
+*  Permission is hereby granted, free of charge, to any person obtaining a copy
+*  of this software and associated documentation files (the "Software"), to
+*  deal in the Software without restriction, including without limitation the
+*  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+*  sell copies of the Software, and to permit persons to whom the Software is
+*  furnished to do so, subject to the following conditions:
+*
+*  The above copyright notice and this permission notice shall be included in
+*  all copies or substantial portions of the Software.
+*
+*  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+*  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+*  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+*  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+*  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+*  IN THE SOFTWARE.
+*/
+
+#include <cppcodec/base64_rfc4648.hpp>
+#include <iostream>
+
+int main(int argc, char *argv[])
+{
+    constexpr const char encoded[] = { "YW55IGNhcm5hbCBwbGVhc3U=" };
+    char decoded[cppcodec::base64_rfc4648::decoded_max_size(sizeof(encoded))];
+    cppcodec::base64_rfc4648::decode(decoded, sizeof(decoded), encoded);
+    std::cout << decoded << '\n';
+    return 0;
+}

--- a/test/test_cppcodec.cpp
+++ b/test/test_cppcodec.cpp
@@ -673,6 +673,9 @@ TEST_CASE("base64 (unpadded URL-safe)", "[base64][url_unpadded]") {
         REQUIRE(base64::decode<std::string>("Zm9vYmE=") == "fooba");
         REQUIRE(base64::decode<std::string>("Zm9vYmFy") == "foobar");
 
+        // Unpadded base64_url allows padding, but an incorrect number of padding characters is still wrong.
+        REQUIRE_THROWS_AS(base64::decode<std::string>("Zg="), cppcodec::padding_error);
+
         // Other test strings.
         REQUIRE(base64::decode<std::string>("MTIz") == "123");
         REQUIRE(base64::decode<std::string>("QUJD") == "ABC");


### PR DESCRIPTION
This started out as simply verifying whether adding a correct `CPPCODEC_ALWAYS_INLINE` macro would fix decoding times for MSVC, and turned into a campaign to make cppcodec performance competitive with some of the top implementations measured by Gaspard Petit in his [base64 benchmark](https://github.com/gaspardpetit/base64). I worked on both Windows and Linux to ensure highest levels of compiler compatibility and verify any performance gains with loads and loads of benchmark runs on all supported platforms/compilers.

The result is that not only is MSVC doing okay now in terms of runtime performance (on both Win32 and x64 builds) but also decoding is 6-8 times faster across the board. On latest GCC Release builds, cppcodec outperforms some of the fastest C implementations such as Apache and Wikibooks.org/C, while keeping all of its features intact and generic for all codecs. On other compilers, performance may still lag by a factor of 2-4 times compared to GCC's best-in-class optimization. They may eventually catch up.

The down-low is that in MinSizeRel builds (roughly equalling -O2), any architecture on any platform will not take longer than about 100 microseconds for a decoded buffer size of 32768 bytes, for either encoding or decoding. Given the fully-featured error handling that cppcodec offers, I say this is pretty damn good enough and warrants another release.

Leaving it here for review for a few more days before I merge it in. The CI bots will verify the performance claims.