### PR TITLE
Deleted unused parameters

### DIFF
--- a/cppcodec/data/access.hpp
+++ b/cppcodec/data/access.hpp
@@ -161,7 +161,7 @@ public:
         // Conditional code paths are slow so we only do it once, at the start.
         m_buffer = result.data();
     }
-    CPPCODEC_ALWAYS_INLINE void put(Result& result, char c)
+    CPPCODEC_ALWAYS_INLINE void put(Result& /*result*/, char c)
     {
         m_buffer[m_offset++] = c;
     }

--- a/cppcodec/detail/base32.hpp
+++ b/cppcodec/detail/base32.hpp
@@ -92,7 +92,7 @@ public:
     template <uint8_t I>
     static CPPCODEC_ALWAYS_INLINE
     uint8_if<I != 1 && I != 3 && I != 4 && I != 6> index_last(
-            const uint8_t* b /*binary block*/)
+            const uint8_t* /*binary block*/)
     {
         throw std::domain_error("invalid last encoding symbol index in a tail");
     }

--- a/cppcodec/detail/base64.hpp
+++ b/cppcodec/detail/base64.hpp
@@ -80,7 +80,7 @@ public:
 
     template <uint8_t I>
     static CPPCODEC_ALWAYS_INLINE uint8_if<I != 1 && I != 2> index_last(
-            const uint8_t* b /*binary block*/)
+            const uint8_t* /*binary block*/)
     {
         throw std::domain_error("invalid last encoding symbol index in a tail");
     }

--- a/cppcodec/detail/stream_codec.hpp
+++ b/cppcodec/detail/stream_codec.hpp
@@ -203,7 +203,7 @@ struct index_if_in_alphabet {
 };
 template <typename CodecVariant, alphabet_index_t InvalidIdx>
 struct index_if_in_alphabet<CodecVariant, InvalidIdx, 0> { // terminating specialization
-    static CPPCODEC_ALWAYS_INLINE constexpr alphabet_index_t for_symbol(char symbol)
+    static CPPCODEC_ALWAYS_INLINE constexpr alphabet_index_t for_symbol(char /*symbol*/)
     {
         return InvalidIdx;
     }
@@ -241,7 +241,7 @@ struct alphabet_index_info
     static constexpr const alphabet_index_t padding_idx = 1 << 8;
     static constexpr const alphabet_index_t invalid_idx = 1 << 9;
     static constexpr const alphabet_index_t eof_idx = 1 << 10;
-    static constexpr const alphabet_index_t stop_character_mask = ~0xFF;
+    static constexpr const alphabet_index_t stop_character_mask = ~alphabet_index_t{0xFF};
 
     static constexpr const bool padding_allowed = padding_searcher<
             CodecVariant, num_possible_symbols>::exists_padding_symbol();


### PR DESCRIPTION
When compiling with Visual Studio with `/W4` enabled, it complains about unused parameters... Cleaned it up.