### PR TITLE
Fix a warning and ensure inlining for less-smart compilers

### DIFF
--- a/cppcodec/data/raw_result_buffer.hpp
+++ b/cppcodec/data/raw_result_buffer.hpp
@@ -41,10 +41,9 @@ public:
     {
     }
 
-    char last() const { return *(m_ptr - 1); }
-    void push_back(char c) { *m_ptr = c; ++m_ptr; }
-    size_t size() const { return m_ptr - m_begin; }
-    void resize(size_t size) { m_ptr = m_begin + size; }
+    CPPCODEC_ALWAYS_INLINE void push_back(char c) { *m_ptr = c; ++m_ptr; }
+    CPPCODEC_ALWAYS_INLINE size_t size() const { return m_ptr - m_begin; }
+    CPPCODEC_ALWAYS_INLINE void resize(size_t size) { m_ptr = m_begin + size; }
 
 private:
     char* m_ptr;
@@ -56,7 +55,7 @@ template <> inline void init<raw_result_buffer>(
         raw_result_buffer& result, empty_result_state&, size_t capacity)
 {
     // This version of init() doesn't do a reserve(), and instead checks whether the
-    // initial size (capacity) is enough before resizing to 0.
+    // initial size (capacity) is enough before resetting m_ptr to m_begin.
     // The codec is expected not to exceed this capacity.
     if (capacity > result.size()) {
         abort();

--- a/cppcodec/detail/stream_codec.hpp
+++ b/cppcodec/detail/stream_codec.hpp
@@ -53,17 +53,17 @@ public:
 
 template <bool GeneratesPadding> // default for CodecVariant::generates_padding() == false
 struct padder {
-    template <typename CodecVariant, typename Result, typename ResultState, typename EncodedBlockSizeT>
-    CPPCODEC_ALWAYS_INLINE void operator()(Result&, ResultState&, EncodedBlockSizeT) { }
+    template <typename CodecVariant, typename Result, typename ResultState, typename SizeT>
+    static CPPCODEC_ALWAYS_INLINE void pad(Result&, ResultState&, SizeT) { }
 };
 
 template<> // specialization for CodecVariant::generates_padding() == true
 struct padder<true> {
-    template <typename CodecVariant, typename Result, typename ResultState, typename EncodedBlockSizeT>
-    CPPCODEC_ALWAYS_INLINE void operator()(
-            Result& encoded, ResultState& state, EncodedBlockSizeT num_padding_characters)
+    template <typename CodecVariant, typename Result, typename ResultState, typename SizeT>
+    static CPPCODEC_ALWAYS_INLINE void pad(
+            Result& encoded, ResultState& state, SizeT num_padding_characters)
     {
-        for (EncodedBlockSizeT i = 0; i < num_padding_characters; ++i) {
+        for (SizeT i = 0; i < num_padding_characters; ++i) {
             data::put(encoded, state, CodecVariant::padding_symbol());
         }
     }
@@ -93,12 +93,6 @@ struct enc {
 
         if (num_symbols == NumSymbols) {
             data::put(encoded, state, CodecVariant::symbol(Codec::template index_last<SymbolIndex>(src)));
-            padder<CodecVariant::generates_padding()> pad;
-#ifdef _MSC_VER
-            pad.operator()<CodecVariant>(encoded, state, Codec::encoded_block_size() - NumSymbols);
-#else
-            pad.template operator()<CodecVariant>(encoded, state, Codec::encoded_block_size() - NumSymbols);
-#endif
             return;
         }
         data::put(encoded, state, CodecVariant::symbol(Codec::template index<SymbolIndex>(src)));
@@ -144,8 +138,14 @@ inline void stream_codec<Codec, CodecVariant>::encode(
             abort();
             return;
         }
-        auto num_symbols = Codec::num_encoded_tail_symbols(static_cast<uint8_t>(remaining_src_len));
+
+        auto num_symbols = Codec::num_encoded_tail_symbols(
+                static_cast<uint8_t>(remaining_src_len));
+
         encoder::template tail<Codec, CodecVariant>(encoded_result, state, src, num_symbols);
+
+        padder<CodecVariant::generates_padding()>::template pad<CodecVariant>(
+                encoded_result, state, Codec::encoded_block_size() - num_symbols);
     }
 }
 


### PR DESCRIPTION
Two relatively unrelated fixes. The only thing that connects them is that I found one issue while looking at the other one, and both have some kind of positive impact on performance. (The warning fix shouldn't have a performance impact but improves my GCC 8.2 release build, whereas the inlining should have a performance impact and *may* perform better on MSVC or maybe that's just a CI server fluke. Either way, there's no negative impact to be found here.)