### PR TITLE
Allow using cppcodec as a CMake dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,8 @@ option(CPPCODEC_BUILD_TESTING "Build cppcodec tests" ${BUILD_TESTING_DEFAULT})
 option(CPPCODEC_BUILD_TOOLS "Build cppcodec tools" ${BUILD_TOOLS_DEFAULT})
 
 # Request C++11, or let the user specify the standard on via -D command line option.
-if (NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 11)
+if(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11)
 endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -101,10 +101,21 @@ endif()
 
 foreach(h ${PUBLIC_HEADERS})
     get_filename_component(FINAL_PATH ${h} DIRECTORY) # once requiring CMake 3.20, switch to cmake_path()
-    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${h} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${FINAL_PATH} COMPONENT "headers")
+    install(
+        FILES ${CMAKE_CURRENT_SOURCE_DIR}/${h}
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${FINAL_PATH}
+        COMPONENT "headers"
+    )
 endforeach()
 
-if (NOT WIN32)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cppcodec.pc.in ${CMAKE_CURRENT_BINARY_DIR}/cppcodec-1.pc @ONLY)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cppcodec-1.pc DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)
+if(NOT WIN32)
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/cppcodec.pc.in
+        ${CMAKE_CURRENT_BINARY_DIR}/cppcodec-1.pc
+        @ONLY
+    )
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/cppcodec-1.pc
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig
+    )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,29 @@
-cmake_minimum_required(VERSION 2.8.5)
+cmake_minimum_required(VERSION 3.13)
 project(cppcodec CXX)
-set(PROJECT_VERSION 0.1)
+set(PROJECT_VERSION 0.3)
 
 include(GNUInstallDirs)
-include(CTest)
 
-# These flags are for binaries built by this particular CMake project (test_cppcodec, base64enc, etc.).
-# In your own project that uses cppcodec, you might want to specify a different standard or error level.
+# Tests, examples and tools are ON by default if built stand-alone,
+# OFF when built as part of another project. Set CPPCODEC_BUILD_* options to override.
+set(BUILD_EXAMPLES_DEFAULT OFF)
+set(BUILD_TESTING_DEFAULT OFF)
+set(BUILD_TOOLS_DEFAULT OFF)
+
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    include(CTest) # note: defines the BUILD_TESTING option which defaults to ON
+    set(BUILD_TESTING_DEFAULT ${BUILD_TESTING})
+    set(BUILD_EXAMPLES_DEFAULT ON)
+    set(BUILD_TOOLS_DEFAULT ON)
+endif()
+
+option(
+    CPPCODEC_BUILD_EXAMPLES
+    "Build cppcodec example code"
+    ${BUILD_EXAMPLES_DEFAULT}
+)
+option(CPPCODEC_BUILD_TESTING "Build cppcodec tests" ${BUILD_TESTING_DEFAULT})
+option(CPPCODEC_BUILD_TOOLS "Build cppcodec tools" ${BUILD_TOOLS_DEFAULT})
 
 # Request C++11, or let the user specify the standard on via -D command line option.
 if (NOT CMAKE_CXX_STANDARD)
@@ -15,21 +32,7 @@ endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-if (MSVC)
-  # MSVC will respect CMAKE_CXX_STANDARD for CMake >= 3.10 and MSVC >= 19.0.24215
-  # (VS 2017 15.3). Older versions will use the compiler default, which should be
-  # fine for anything except ancient MSVC versions.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
-else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic")
-
-  # CMake versions before 3.1 do not understand CMAKE_CXX_STANDARD.
-  # Remove this block once CMake >=3.1 has fixated in the ecosystem.
-  if(${CMAKE_VERSION} VERSION_LESS 3.1)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++${CMAKE_CXX_STANDARD}")
-  endif()
-endif()
-
+# Relative paths, used also for install(). Use #include paths like this.
 set(PUBLIC_HEADERS
     # base32
     cppcodec/base32_crockford.hpp
@@ -59,19 +62,45 @@ set(PUBLIC_HEADERS
     cppcodec/detail/codec.hpp
     cppcodec/detail/config.hpp
     cppcodec/detail/hex.hpp
-    cppcodec/detail/stream_codec.hpp)
+    cppcodec/detail/stream_codec.hpp
+)
 
-add_library(cppcodec OBJECT ${PUBLIC_HEADERS}) # unnecessary for building, but makes headers show up in IDEs
+add_library(cppcodec INTERFACE)
+target_sources(cppcodec INTERFACE ${PUBLIC_HEADERS})
 set_target_properties(cppcodec PROPERTIES LINKER_LANGUAGE CXX)
-add_subdirectory(tool)
-add_subdirectory(example)
 
-if (BUILD_TESTING)
+target_include_directories(
+    cppcodec
+    INTERFACE
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:include>
+)
+
+# These flags are for binaries built by this particular CMake project (test_cppcodec, base64enc, etc.).
+# In your own project that uses cppcodec, you might want to specify a different standard or error level.
+if(MSVC)
+    # MSVC will respect CMAKE_CXX_STANDARD for CMake >= 3.10 and MSVC >= 19.0.24215
+    # (VS 2017 15.3). Older versions will use the compiler default, which should be
+    # fine for anything except ancient MSVC versions.
+    set(CPPCODEC_PRIVATE_COMPILE_OPTIONS /W4) # /WX for failing on errors
+else()
+    set(CPPCODEC_PRIVATE_COMPILE_OPTIONS -Wall -Wextra -pedantic) # -Werror for failing on errors
+endif()
+
+if(CPPCODEC_BUILD_TESTING)
     add_subdirectory(test)
 endif()
 
+if(CPPCODEC_BUILD_TOOLS)
+    add_subdirectory(tool)
+endif()
+
+if(CPPCODEC_BUILD_EXAMPLES)
+    add_subdirectory(example)
+endif()
+
 foreach(h ${PUBLIC_HEADERS})
-    get_filename_component(FINAL_PATH ${h} PATH) # use DIRECTORY instead of PATH once requiring CMake 3.0
+    get_filename_component(FINAL_PATH ${h} DIRECTORY) # once requiring CMake 3.20, switch to cmake_path()
     install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${h} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${FINAL_PATH} COMPONENT "headers")
 endforeach()
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,6 +1,7 @@
-# For cppcodec itself, don't prefer system headers over development ones.
-include_directories(BEFORE ${PROJECT_SOURCE_DIR})
+add_compile_options(${CPPCODEC_PRIVATE_COMPILE_OPTIONS})
 
 add_executable(helloworld helloworld.cpp)
+target_link_libraries(helloworld cppcodec)
 
 add_executable(type_support_wrapper type_support_wrapper.cpp)
+target_link_libraries(type_support_wrapper cppcodec)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,9 @@
 find_package(PkgConfig)
-if (PKG_CONFIG_FOUND)
+if(PKG_CONFIG_FOUND)
     pkg_check_modules(CATCH2 catch2)
 endif()
 
-if (CATCH2_FOUND)
+if(CATCH2_FOUND)
     message(STATUS "Found system Catch2, not using bundled version")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CATCH2_CFLAGS}")
 else()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,3 @@
-# For cppcodec itself, don't prefer system headers over development ones.
-include_directories(BEFORE ${PROJECT_SOURCE_DIR})
-
 find_package(PkgConfig)
 if (PKG_CONFIG_FOUND)
     pkg_check_modules(CATCH2 catch2)
@@ -14,9 +11,14 @@ else()
     include_directories(${CMAKE_CURRENT_SOURCE_DIR}/catch/single_include)
 endif()
 
+add_compile_options(${CPPCODEC_PRIVATE_COMPILE_OPTIONS})
+
 add_executable(test_cppcodec test_cppcodec.cpp)
-add_test(cppcodec test_cppcodec)
+target_link_libraries(test_cppcodec cppcodec)
+add_test(NAME cppcodec COMMAND test_cppcodec)
 
 add_executable(benchmark_cppcodec benchmark_cppcodec.cpp)
+target_link_libraries(benchmark_cppcodec cppcodec)
 
 add_executable(minimal_decode minimal_decode.cpp)
+target_link_libraries(minimal_decode cppcodec)

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -1,11 +1,19 @@
-# For cppcodec itself, don't prefer system headers over development ones.
-include_directories(BEFORE ${PROJECT_SOURCE_DIR})
+add_compile_options(${CPPCODEC_PRIVATE_COMPILE_OPTIONS})
 
 add_executable(base32enc base32enc.cpp)
+target_link_libraries(base32enc cppcodec)
+
 add_executable(base32dec base32dec.cpp)
+target_link_libraries(base32dec cppcodec)
 
 add_executable(base64enc base64enc.cpp)
+target_link_libraries(base64enc cppcodec)
+
 add_executable(base64dec base64dec.cpp)
+target_link_libraries(base64dec cppcodec)
 
 add_executable(hexenc hexenc.cpp)
+target_link_libraries(hexenc cppcodec)
+
 add_executable(hexdec hexdec.cpp)
+target_link_libraries(hexdec cppcodec)


### PR DESCRIPTION
A continuation/refinement of PR #73, which does not get updates as the author wasn't the submitter of the PR. This PR I can change and hopefully merge.

This makes CMakeLists.txt suitable for inclusion into a
parent CMake project via `add_subdirectory()` command,
and defines the `cppcodec` target as `INTERFACE` library.
Use it in a `target_link_libraries()` command as dependency
in order to add cppcodec's include directories to your target.

The minimum CMake requirement is now 3.13, picking up various
improvements to `INTERFACE` library targets and avoiding any
confusion around CMake policy CMP0076, a behavior changed in 3.13.

The CMake build will now build tests, examples and tools if built
stand-alone, but exclude them if built as part of another project.
This can be customized via `CPPCODEC_BUILD_{TESTING,EXAMPLES,TOOLS}`
CMake definitions for a given build.

Fixes #60
Fixes #61

This commit is based on changes by Quintz Gábor (@quiga on GitHub),
but modified and extended in a number of ways.

Thanks also to Aditya Gupta (@adi-g15), anonymous @ghuser404
and Kingsley Chen (@kingsamchen) for keeping this issue on
my radar and providing valuable feedback.

Includes an extra commit for standard CMake formatting with gersemi. The main commit changes only lines with semantic differences.